### PR TITLE
CRAYSAT-1288: Skip setting active version

### DIFF
--- a/cray_product_catalog/catalog_update.py
+++ b/cray_product_catalog/catalog_update.py
@@ -62,7 +62,7 @@ PRODUCT_VERSION = os.environ.get("PRODUCT_VERSION").strip()  # required
 CONFIG_MAP = os.environ.get("CONFIG_MAP", "cray-product-catalog").strip()
 CONFIG_MAP_NAMESPACE = os.environ.get("CONFIG_MAP_NAMESPACE", "services").strip()
 YAML_CONTENT = os.environ.get("YAML_CONTENT").strip()  # required
-SKIP_SET_ACTIVE_VERSION = bool(os.environ.get("SKIP_SET_ACTIVE_VERSION"))
+SET_ACTIVE_VERSION = bool(os.environ.get("SET_ACTIVE_VERSION"))
 VALIDATE_SCHEMA = bool(os.environ.get("VALIDATE_SCHEMA"))
 
 
@@ -170,13 +170,13 @@ def update_config_map(data, name, namespace):
             # Key with same version exists in ConfigMap
             else:
                 if (data.items() <= product_data[PRODUCT_VERSION].items()
-                        and (current_version_is_active(product_data) or SKIP_SET_ACTIVE_VERSION)):
+                        and (current_version_is_active(product_data) or not SET_ACTIVE_VERSION)):
                     LOGGER.info("ConfigMap data updates exist; Exiting.")
                     break
 
         # Patch the config map if needed
         product_data[PRODUCT_VERSION].update(data)
-        if not SKIP_SET_ACTIVE_VERSION:
+        if SET_ACTIVE_VERSION:
             set_active_version(product_data)
         config_map_data[PRODUCT] = yaml.safe_dump(
             product_data, default_flow_style=False
@@ -196,9 +196,9 @@ def main():
         CONFIG_MAP, CONFIG_MAP_NAMESPACE, PRODUCT, PRODUCT_VERSION
     )
 
-    if SKIP_SET_ACTIVE_VERSION:
+    if SET_ACTIVE_VERSION:
         LOGGER.info(
-            "Not setting %s:%s to active because SKIP_SET_ACTIVE_VERSION was set.",
+            "Setting %s:%s to active because SET_ACTIVE_VERSION was set.",
             PRODUCT, PRODUCT_VERSION
         )
 


### PR DESCRIPTION
## Summary and Scope
This commit changes the default behavior so that running cray-product-catalog-update does not set a particular version to 'active', unless the SET_ACTIVE_VERSION variable is set in the environment. This makes the behavior more in line with previous versions which were not setting any "active" data.

## Issues and Related PRs
### Testing
Tested on: Thanos
Test description: https://gist.github.hpe.com/eli-kamin/56c7fb39a82be251634e854ddbe1b9d0

## Pull Request Checklist
[N/A] Version number(s) incremented, if applicable
[N/A] Copyrights updated
[Y] License file intact
[Y] Target branch correct
[Y] CHANGELOG.md updated
[Y] Testing is appropriate and complete, if applicable
[N/A] HPC Product Announcement prepared, if applicable**

