### PR TITLE
let pr artifacts workflow time out and exit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -41,9 +41,6 @@ _Are there known issues with these changes? Any other special considerations?_
 
 ## Pull Request Checklist
 
-- [ ] Version number(s) incremented, if applicable
-- [ ] Copyrights updated
-- [ ] License file intact
 - [ ] Target branch correct
 - [ ] Testing is appropriate and complete, if applicable
 - [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

--- a/.github/workflows/gitflow-mergeback.yml
+++ b/.github/workflows/gitflow-mergeback.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   merge-to-develop:
-    # this job will only run if the PR has been merged, not simply closed
+    # this job will only run if the PR has been merged, not just closed
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
@@ -37,8 +37,8 @@ jobs:
         uses: navikt/github-app-token-generator@v1
         id: get-token
         with:
-          private-key: ${{ secrets.CSM_MANIFEST_AUTOUPDATER_APP_KEY }}
-          app-id: ${{ secrets.CSM_MANIFEST_AUTOUPDATER_APP_ID }}
+          private-key: ${{ secrets.CSM_GITFLOW_MERGEBACK_BOT_APP_ID }}
+          app-id: ${{ secrets.CSM_GITFLOW_MERGEBACK_BOT_APP_KEY }}
 
       - uses: actions/checkout@v2
         with:
@@ -59,6 +59,7 @@ jobs:
           branch: mergeback-master-${{ github.event.pull_request.head.ref }}
           branch-suffix: timestamp
           base: develop
+          delete-branch: true
           title: "[chore] Master -> Develop from PR #${{ github.event.pull_request.number }} (${{ github.event.pull_request.head.ref }})"
           signoff: true
           assignees: ${{ github.actor }}

--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 name: Add artifact information to PR
 on:
-  pull_request: 
+  pull_request:
 
 # Globals
 env:
@@ -34,11 +34,12 @@ env:
 
 # Workflow Jobs
 jobs:
-  update-pr-with-artifacts:
+  wait-for-deploy-script:
     runs-on: ubuntu-latest
+    outputs:
+      conclusion: ${{ steps.wait-for-build.outputs.conclusion }}
+
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
 
       - name: Wait for push build to succeed and upload deploy script
         uses: fountainhead/action-wait-for-check@v1.0.0
@@ -48,14 +49,34 @@ jobs:
           checkName: publish-deploy-script
           ref: ${{ github.event.pull_request.head.sha }}
 
+      # Some PRs don't have push branch builds (master, for example). Don't
+      # attempt to update the PR with artifact locations in a comment, just
+      # exit cleanly.
+      - name: Check timed out
+        if: steps.wait-for-build.outputs.conclusion == 'timed_out'
+        run: |
+          echo "The check has timed out; exiting cleanly."
+
+  update-pr-with-artifacts:
+    runs-on: ubuntu-latest
+    if: needs.wait-for-deploy-script.outputs.conclusion != 'timed_out'
+    needs:
+      - wait-for-deploy-script
+
+    steps:
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
       - name: Wait a while for the github api to report the workflow/artifact
         run: |
           # Kinda expected the previous action to do this, but it doesn't always
           # end up that way.
+          echo conclusion: ${{ needs.wait-for-deploy-script.outputs.conclusion }}
           sleep 60;
 
       - name: Download deploy script artifact
-        if: steps.wait-for-build.outputs.conclusion == 'success'
+        if: needs.wait-for-deploy-script.outputs.conclusion == 'success'
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: build-artifacts.yml
@@ -64,7 +85,7 @@ jobs:
           name: deploy-script.sh
 
       - name: Download artifacts.json
-        if: steps.wait-for-build.outputs.conclusion == 'success'
+        if: needs.wait-for-deploy-script.outputs.conclusion == 'success'
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: build-artifacts.yml
@@ -79,12 +100,12 @@ jobs:
           echo "::set-output name=artifacts::${JSON//'%'/'%25'}"
 
       - name: Inject deploy script into pr artifacts template
-        if: steps.wait-for-build.outputs.conclusion == 'success'
+        if: needs.wait-for-deploy-script.outputs.conclusion == 'success'
         run: |
           sed -i -e '/# script #/r./deploy-script.sh' .github/templates/pr-artifacts.md.tmpl
 
       - name: Render artifacts comment template
-        if: steps.wait-for-build.outputs.conclusion == 'success'
+        if: needs.wait-for-deploy-script.outputs.conclusion == 'success'
         uses: chuhlomin/render-template@v1.4
         id: template
         with:
@@ -102,7 +123,7 @@ jobs:
             pymodUrl: "${{fromJson(steps.set-json-vars.outputs.artifacts).pymod_url}}"
 
       - name: Create commit comment
-        if: steps.wait-for-build.outputs.conclusion == 'success'
+        if: needs.wait-for-deploy-script.outputs.conclusion == 'success'
         uses: peter-evans/commit-comment@v1
         with:
           sha: ${{ github.event.pull_request.head.sha }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Let PR artifacts deploy workflow time out if it doesn't find a matching build
+
 ## [1.4.20] - 2022-01-26
 
 ### Changed


### PR DESCRIPTION
## Summary and Scope

For some branches (like master), artifact builds are not run because builds are not needed here (tags are built instead). When these commits get merged back to develop, the PR artifact workflow is looking for the build from the commit that was pushed to master, which does not exist.

Instead of trying to determine if the build exists, just let it time out.