### PR TITLE
Remove redundant license/copyright info from README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Remove redundant license/copyright info from README
+
 ## [1.4.23] - 2022-01-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -145,14 +145,3 @@ See the [CHANGELOG](CHANGELOG.md) for changes.
 This project is copyrighted by Hewlett Packard Enterprise Development LP and is under the MIT
 license. See the [LICENSE](LICENSE) file for details.
 
-When making any modifications to a file that has a Cray/HPE copyright header, that header
-must be updated to include the current year.
-
-When creating any new files in this repo, if they contain source code, they must have
-the HPE copyright and license text in their header, unless the file is covered under
-someone else's copyright/license (in which case that should be in the header). For this
-purpose, source code files include Dockerfiles, Ansible files, RPM spec files, and shell
-scripts. It does **not** include Jenkinsfiles, OpenAPI/Swagger specs, or READMEs.
-
-When in doubt, provided the file is not covered under someone else's copyright or license, then
-it does not hurt to add ours to the header.


### PR DESCRIPTION
## Summary and Scope

Remove redundant license/copyright info from README

Also testing what happens from a fork.