### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2022-02-01
+
 ### Added
 - Added reference to Keep a Changelog format to README file
 - Added reference to CSM Gitflow development process to README file
@@ -169,7 +171,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated repo to Gitflow branching strategy; develop branch now base branch
 - Change default reviewers to CMS-core-product-support
 
-[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog/compare/1.4.23...HEAD
+[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog/compare/1.5.0...HEAD
+
+[1.5.0]: https://github.com/Cray-HPE/cray-product-catalog/compare/1.4.23...1.5.0
 
 [1.4.23]: https://github.com/Cray-HPE/cray-product-catalog/compare/1.4.22...1.4.23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added reference to Keep a Changelog format to README file
+- Added reference to CSM Gitflow development process to README file
 
 ### Removed
 - Remove redundant license/copyright info from README

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -6,7 +6,7 @@ branches:
     mode: ContinuousDelivery
   develop:
     regex: ^develop$
-    increment: Patch
+    increment: Minor
     mode: ContinuousDeployment
   release:
     # Do not consider legacy release/[shasta,csm]-* branches as gitflow release branches

--- a/README.md
+++ b/README.md
@@ -123,8 +123,10 @@ are merged.
 
 ## Contributing
 
-This repo uses [Git Flow](https://nvie.com/posts/a-successful-git-branching-model/). 
-CMS-core-product-support team members shouuld make a branch. Others, make a fork.
+This repo uses [Git Flow](https://nvie.com/posts/a-successful-git-branching-model/)
+and the [CSM Gitflow Development Process]( https://github.com/Cray-HPE/community/wiki/Gitflow-Development-Process).
+
+CMS-core-product-support team members should make a branch. Others, make a fork.
 
 ## Built With
 


### PR DESCRIPTION
## Summary and Scope

- Remove redundant license/copyright info from README
- CASMFEAT-1234: update README to reference LICENSE FILE
- Default develop increment to Minor in GitVersion config
- Add CSM Gitflow Development link to README
- Update changelog for README modifications
- Prepare release v1.5.0

## Testing

N/A

## Risks and Mitigations

None, this PR is just for demonstration purposes.


## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

