### PR TITLE
Add automerge capability to git mergeback PRs

### DIFF
--- a/.github/workflows/gitflow-mergeback.yml
+++ b/.github/workflows/gitflow-mergeback.yml
@@ -60,7 +60,7 @@ jobs:
           branch-suffix: timestamp
           base: develop
           delete-branch: true
-          title: "[chore] Master -> Develop from PR #${{ github.event.pull_request.number }} (${{ github.event.pull_request.head.ref }})"
+          title: "[chore] Master -> Develop from PR ${{ github.repository }}#${{ github.event.pull_request.number }} (${{ github.event.pull_request.head.ref }})"
           signoff: true
           assignees: ${{ github.actor }}
           committer: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
@@ -89,3 +89,18 @@ jobs:
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+
+      - name: Enable Pull Request Automerge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v1
+        with:
+          token: ${{ steps.get-token.outputs.token }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: merge
+
+      - name: Auto approve
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: juliangruber/approve-pull-request-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.5.0] - 2022-02-01
 
 ### Added
+
+- Automerge capabilities for gitflow mergeback PRs
+
+### Changed
+
+- PR title in gitflow mergeback PRs is repo-specific so including them in
+  release notes and in different repo PRs, they refer to original PRs
+
+## [1.5.0] - 2022-02-01
+
+### Added
+
 - Added reference to Keep a Changelog format to README file
 - Added reference to CSM Gitflow development process to README file
 
 ### Removed
+
 - Remove redundant license/copyright info from README
 
 ## [1.4.23] - 2022-01-27
@@ -171,7 +184,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated repo to Gitflow branching strategy; develop branch now base branch
 - Change default reviewers to CMS-core-product-support
 
-[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog/compare/1.5.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog/compare/1.5.1...HEAD
+
+[1.5.0]: https://github.com/Cray-HPE/cray-product-catalog/compare/1.5.0...1.5.1
 
 [1.5.0]: https://github.com/Cray-HPE/cray-product-catalog/compare/1.4.23...1.5.0
 


### PR DESCRIPTION
## Summary and Scope

Also fix PRs references to fully reference the repository and PR number instead of just the PR number, which can confuse GitHub autolinking if the reference is included in other repo PRs (such as when release notes are added to a CSM manifest update PR

## Testing

N/A

## Risks and Mitigations

N/A

## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

