### PR TITLE
Hotfix 1.5.2 - remove auto-approve from merge back workflow

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -29,7 +29,10 @@ on:
 jobs:
   check-changelog:
     runs-on: ubuntu-latest
-    if: "!(contains(github.event.pull_request.labels.*.name, 'gitflow-maintenance') ||  contains(github.event.pull_request.labels.*.name, 'dependabot'))"
+    if: "!(
+      contains(github.event.pull_request.labels.*.name, 'gitflow-maintenance') || 
+      contains(github.event.pull_request.labels.*.name, 'dependabot')
+      )"
     steps:
 
       - uses: actions/checkout@v2
@@ -47,6 +50,5 @@ jobs:
       - name: Ensure the changelog file has changed
         if: steps.changed-files.outputs.any_modified != 'true'
         run: |
-
           echo "Changelog has not been modified. Please add a changelog entry in accordance with https://keepachangelog.com"
           exit 1;

--- a/.github/workflows/gitflow-mergeback.yml
+++ b/.github/workflows/gitflow-mergeback.yml
@@ -97,10 +97,3 @@ jobs:
           token: ${{ steps.get-token.outputs.token }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           merge-method: merge
-
-      - name: Auto approve
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: juliangruber/approve-pull-request-action@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/update-csm-manifest.yml
+++ b/.github/workflows/update-csm-manifest.yml
@@ -103,7 +103,7 @@ jobs:
           VERSION: "${{fromJson(steps.set-json-vars.outputs.artifacts).CHART_VERSION}}"
           CHART: ${{ env.CHART_NAME }}
 
-      - name: Debug Print Manifest File
+      - name: Print Manifest File
         run: |
           cat ./csm/manifests/sysmgmt.yaml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.5.0] - 2022-02-01
+## [1.5.2] - 2022-02-02
+
+### Removed
+
+- Autoapprove PR action for gitflow mergeback PRs
+
+## [1.5.1] - 2022-02-02
 
 ### Added
 
@@ -184,9 +190,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated repo to Gitflow branching strategy; develop branch now base branch
 - Change default reviewers to CMS-core-product-support
 
-[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog/compare/1.5.1...HEAD
+[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog/compare/1.5.2...HEAD
 
-[1.5.0]: https://github.com/Cray-HPE/cray-product-catalog/compare/1.5.0...1.5.1
+[1.5.2]: https://github.com/Cray-HPE/cray-product-catalog/compare/1.5.0...1.5.2
+
+[1.5.1]: https://github.com/Cray-HPE/cray-product-catalog/compare/1.5.0...1.5.1
 
 [1.5.0]: https://github.com/Cray-HPE/cray-product-catalog/compare/1.4.23...1.5.0
 


### PR DESCRIPTION
## Summary and Scope

Remove the auto-approve action from the gitlfow-mergeback.yml workflow.
This did not work as intended and causes a failure in the workflow.

## Testing

N/A

## Risks and Mitigations

N/A

## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

