### PR TITLE
Update to sbom/image signing actions using gcp idp

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -460,6 +460,9 @@ jobs:
     if: ${{ fromJSON(needs.build-scan-sign-publish-image.outputs.snyk-passed) }}
     needs: 
       - build-scan-sign-publish-image
+    permissions:
+      contents: 'read'
+      id-token: 'write'
 
     steps:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update the image signing and software bill of materials github actions (Cray
+  HPE internal actions) to use the preferred GCP authentication.
+
 ## [1.5.4] - 2022-02-15
 
 ### Changed


### PR DESCRIPTION
## Summary and Scope

Update the image signing and software bill of materials github actions (Cray HPE internal actions) to use the preferred GCP authentication.

## Issues and Related PRs

* Resolves https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7857

## Testing

### Tested on:

  * See builds for this branch

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable

