### PR TITLE
CASMCMS-7928: Update deploy script for CSM 1.2/Nexus auth

### DIFF
--- a/.github/templates/deploy-script.sh.tmpl
+++ b/.github/templates/deploy-script.sh.tmpl
@@ -6,15 +6,17 @@
 #   repository: {{ .repository }}
 #   generator: {{ .run }}
 
-cat <<EOF > image-download-{{ .commit }}.sh
+cat << 'EOF' > image-download-{{ .commit }}.sh
 #!/usr/bin/env bash
 
-zypper addrepo https://slemaster.us.cray.com/SUSE/Products/SLE-Module-Server-Applications/15-SP2/x86_64/product {{ .zypperRepoName }}
-zypper refresh
-zypper in -y --repo {{ .zypperRepoName }} skopeo
+NEXUS_USERNAME="$(kubectl -n nexus get secret nexus-admin-credential --output json | jq -r .data.username | base64 -d)"
+NEXUS_PASSWORD="$(kubectl -n nexus get secret nexus-admin-credential --output json | jq -r .data.password | base64 -d)"
 echo "Downloading remote image {{ .fullImage }} to system registry"
-skopeo copy --dest-tls-verify=false docker://{{ .fullImage }} docker://registry.local/cray/{{ .imageName }}:{{ .imageTag }}
-zypper rr {{ .zypperRepoName }}
+podman run --rm --network host quay.io/skopeo/stable copy --src-tls-verify=false --dest-tls-verify=false \
+    docker://{{ .fullImage }} \
+    docker://registry.local/{{ .fullImage }} \
+    --dest-username "${NEXUS_USERNAME}"  \
+    --dest-password "${NEXUS_PASSWORD}"
 EOF
 
 cat <<EOF > manifest.raw.{{ .commit }}.yaml

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -398,7 +398,6 @@ jobs:
       - name: Create additional template vars
         id: vars
         run: |
-          echo ::set-output name=repo_name::$(echo ${GITHUB_REPOSITORY}_${GITHUB_REF_NAME} | sed 's|/|_|g')
           echo ::set-output name=image::$(echo ${IMAGE_NAME}:${IMAGE_TAG})
           echo ::set-output name=image_tag::$(echo ${IMAGE_TAG})
           echo ::set-output name=image_url::$(echo https://artifactory.algol60.net/ui/repos/tree/General/csm-docker%2F${STABLE}%2F${IMAGE_NAME}%2F${IMAGE_TAG})
@@ -421,7 +420,6 @@ jobs:
             fullImage: ${{ needs.build-scan-sign-publish-image.outputs.full-image }}
             imageName: ${{ env.IMAGE_NAME }}
             imageTag: ${{ env.IMAGE_TAG }}
-            zypperRepoName: ${{ steps.vars.outputs.repo_name }}
             commit: ${{ needs.build-prep.outputs.short-sha }}
             ref: ${{ github.ref_name }}
             ref_type: ${{ github.ref_type }}

--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -126,6 +126,7 @@ jobs:
 
       - name: Render artifacts comment template
         if: needs.wait-for-deploy-script.outputs.conclusion == 'success'
+        continue-on-error: true
         uses: chuhlomin/render-template@v1.4
         id: template
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update license text to comply with automatic license-check tool.
 
+- Update deploy script to work with CSM 1.2 systems and Nexus authentication
+
 ## [1.5.5] - 2022-03-04
 
 ### Changed


### PR DESCRIPTION
## Summary and Scope

Update the deploy script to use nexus authentication to push a new docker image to the registry.

## Issues and Related PRs


* Resolves CASMCMS-7928

## Testing

### Tested on:

  * `mug`

### Test description:

Downloaded the script from GH actions output and ran it.

```text
ncn-m001:~/rkleinman # cat image-download-f5bef17.sh
#!/usr/bin/env bash

NEXUS_USERNAME="$(kubectl -n nexus get secret nexus-admin-credential --template {{.data.username}} | base64 -d)"
NEXUS_PASSWORD="$(kubectl -n nexus get secret nexus-admin-credential --template {{.data.password}} | base64 -d)"
echo "Downloading remote image artifactory.algol60.net/csm-docker/unstable/cray-product-catalog-update:1.6.0-CASMCMS-7928.1.20220324151321.f5bef17 to system registry"
podman run --rm --network host quay.io/skopeo/stable copy --src-tls-verify=false --dest-tls-verify=false \
    docker://artifactory.algol60.net/csm-docker/unstable/cray-product-catalog-update:1.6.0-CASMCMS-7928.1.20220324151321.f5bef17 \
    docker://registry.local/artifactory.algol60.net/csm-docker/unstable/cray-product-catalog-update:1.6.0-CASMCMS-7928.1.20220324151321.f5bef17 \
    --dest-username "${NEXUS_USERNAME}"  \
    --dest-password "${NEXUS_PASSWORD}"
ncn-m001:~/rkleinman # bash ./image-download-f5bef17.sh
Downloading remote image artifactory.algol60.net/csm-docker/unstable/cray-product-catalog-update:1.6.0-CASMCMS-7928.1.20220324151321.f5bef17 to system registry
Getting image source signatures
Copying blob sha256:04019a7082b80e4c430568b0db57214f1c61964c9ef912f73096fc81a96e5c66
Copying blob sha256:e1096b72685a2366348e697f5b57e3b8feb41660e3dbe68447e168381515111a
Copying blob sha256:2fd4b38f6310244d10229ae1193e97b068f439f648ab2cbbc38623f378460705
Copying blob sha256:79c26566f1e72239e0ad529edbc97ade1592330ea1dcd01355c20754b3014624
Copying blob sha256:5cb88120bdd0101de75e947045c5c562c0ed3cb88d35a6b9ac46e4ead78e90b1
Copying blob sha256:9eef1f1e6e8b2bc15bf17160aaf2a603a277bffe0543d6eb2586bcbc1cc02195
Copying blob sha256:02c579c3d2495c0ceffd20a7d6546e4a96964a0fc22bf1833b22ba7fd474b6e7
Copying blob sha256:3fbec2d2b6b5fae0e506b037cd920a5894f73537058dd37d68b76479c386caad
Copying config sha256:d5492a11312526fb8f2b94ad1d889bff5e63b0a02092a8d9b44744a012ed37ae
Writing manifest to image destination
Storing signatures
```

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Is a new version being released? Update https://github.com/Cray-HPE/cray-product-catalog/wiki/CSM-Compatibility-Matrix

