### PR TITLE
CASMCMS-7959 - Update alpine base image to newer version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update base image to artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.15
+
 - Update license text to comply with automatic license-check tool.
 
 - Update deploy script to work with CSM 1.2 systems and Nexus authentication

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-FROM artifactory.algol60.net/docker.io/alpine:3.13 as base
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.15 as base
 RUN apk add --no-cache py3-pip python3
 ARG PYMOD_VERSION=0.0.0
 


### PR DESCRIPTION
## Summary and Scope

Update the base image to alpine:3.15 from the nightly build location.

## Issues and Related PRs
* Resolves [CASMCMS-7959](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7959)

## Testing
### Tested on:

  * `Wasp`

### Test description:

Not tested - can't get this to build before it is merged into develop.

## Risks and Mitigations

This is a low risk change as we are just updating the base image version for CVE patches.

## Pull Request Checklist

- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Is a new version being released? Update https://github.com/Cray-HPE/cray-product-catalog/wiki/CSM-Compatibility-Matrix