### PR TITLE
Add product catalog query module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added new `query` module to query the `cray-product-catalog` K8s ConfigMap to
+  obtain information about the installed products.
+
+### Changed
+
 - Update license text to comply with automatic license-check tool.
 
 - Update deploy script to work with CSM 1.2 systems and Nexus authentication

--- a/cray_product_catalog/catalog_delete.py
+++ b/cray_product_catalog/catalog_delete.py
@@ -46,11 +46,13 @@ import time
 import urllib3
 from urllib3.util.retry import Retry
 
-from kubernetes import client, config
+from kubernetes import client
 from kubernetes.client.api_client import ApiClient
 from kubernetes.client.configuration import Configuration
 from kubernetes.client.rest import ApiException
 import yaml
+
+from cray_product_catalog.util import load_k8s
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -60,14 +62,6 @@ LOGGER.setLevel(logging.INFO)
 handler = logging.StreamHandler(sys.stdout)
 handler.setLevel(logging.DEBUG)
 LOGGER.addHandler(handler)
-
-
-def load_k8s():
-    """ Load Kubernetes Configuration """
-    try:
-        config.load_incluster_config()
-    except Exception:
-        config.load_kube_config()
 
 
 def modify_config_map(name, namespace, product, product_version, key=None):

--- a/cray_product_catalog/catalog_update.py
+++ b/cray_product_catalog/catalog_update.py
@@ -40,13 +40,14 @@ import urllib3
 from urllib3.util.retry import Retry
 
 from jsonschema.exceptions import ValidationError
-from kubernetes import client, config
+from kubernetes import client
 from kubernetes.client.api_client import ApiClient
 from kubernetes.client.configuration import Configuration
 from kubernetes.client.rest import ApiException
 import yaml
 
 from cray_product_catalog.schema.validate import validate
+from cray_product_catalog.util import load_k8s
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -65,14 +66,6 @@ CONFIG_MAP_NAMESPACE = os.environ.get("CONFIG_MAP_NAMESPACE", "services").strip(
 YAML_CONTENT = os.environ.get("YAML_CONTENT").strip()  # required
 SET_ACTIVE_VERSION = bool(os.environ.get("SET_ACTIVE_VERSION"))
 VALIDATE_SCHEMA = bool(os.environ.get("VALIDATE_SCHEMA"))
-
-
-def load_k8s():
-    """ Load Kubernetes Configuration """
-    try:
-        config.load_incluster_config()
-    except Exception:
-        config.load_kube_config()
 
 
 def validate_schema(data):

--- a/cray_product_catalog/constants.py
+++ b/cray_product_catalog/constants.py
@@ -1,0 +1,32 @@
+"""
+Defines classes for querying for information about the installed products.
+
+MIT License
+
+(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+PRODUCT_CATALOG_CONFIG_MAP_NAME = 'cray-product-catalog'
+PRODUCT_CATALOG_CONFIG_MAP_NAMESPACE = 'services'
+COMPONENT_VERSIONS_PRODUCT_MAP_KEY = 'component_versions'
+COMPONENT_REPOS_KEY = 'repositories'
+COMPONENT_DOCKER_KEY = 'docker'
+LATEST_VERSION_STRING = 'latest'

--- a/cray_product_catalog/query.py
+++ b/cray_product_catalog/query.py
@@ -214,57 +214,8 @@ class InstalledProductVersion:
         Returns:
             A list of tuples of (image_name, image_version)
         """
-        # If there is no 'docker' key under the component data, assume that there
-        # is a single docker image named cray/cray-PRODUCT whose version is the
-        # value of the PRODUCT key under component_versions.
-        if COMPONENT_DOCKER_KEY not in self.component_data:
-            return [(self._deprecated_docker_image_name, self._deprecated_docker_image_version)]
-
         return [(component['name'], component['version'])
                 for component in self.component_data.get(COMPONENT_DOCKER_KEY) or []]
-
-    @property
-    def _deprecated_docker_image_version(self):
-        """str: The Docker image version associated with this product version, or None.
-
-        Note: this assumes that the 'component_versions' data is structured as follows:
-        component_versions:
-            product_name: docker_image_version
-
-        Newer versions will structure the 'component_versions' data as follows:
-        component_versions:
-            product_name:
-                docker:
-                    docker_image_name_1: docker_image_version
-                    docker_image_name_2: docker_image_version
-
-        This method should only be used if the installed version does not have a
-        component_versions->product_name->docker key.
-        """
-        return self.component_data.get(self.name)
-
-    @property
-    def _deprecated_docker_image_name(self):
-        """str: The Docker image name associated with this product version.
-
-        Note: this assumes that the 'component_versions' data is structured as follows:
-        component_versions:
-            product_name: docker_image_version
-
-        It also assumes that the name of the singular docker image is
-        'cray/cray-<product_name'.
-
-        Newer versions will structure the 'component_versions' data as follows:
-        component_versions:
-            product_name:
-                docker:
-                    docker_image_name_1: docker_image_version
-                    docker_image_name_2: docker_image_version
-
-        This method should only be used if the installed version does not have a
-        component_versions->product_name->docker key.
-        """
-        return f'cray/cray-{self.name}'
 
     @property
     def repositories(self):

--- a/cray_product_catalog/query.py
+++ b/cray_product_catalog/query.py
@@ -26,14 +26,13 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 import logging
 from pkg_resources import parse_version
-import warnings
 
 from jsonschema.exceptions import ValidationError
 from kubernetes.client import CoreV1Api
 from kubernetes.client.rest import ApiException
-from kubernetes.config import load_kube_config, ConfigException
+from kubernetes.config import ConfigException
 from urllib3.exceptions import MaxRetryError
-from yaml import safe_load, YAMLError, YAMLLoadWarning
+from yaml import safe_load, YAMLError
 
 from cray_product_catalog.constants import (
     COMPONENT_DOCKER_KEY,
@@ -75,9 +74,7 @@ class ProductCatalog:
                 Kubernetes configuration.
         """
         try:
-            with warnings.catch_warnings():
-                warnings.filterwarnings('ignore', category=YAMLLoadWarning)
-                load_k8s()
+            load_k8s()
             return CoreV1Api()
         except ConfigException as err:
             raise ProductCatalogError(f'Unable to load kubernetes configuration: {err}.')

--- a/cray_product_catalog/query.py
+++ b/cray_product_catalog/query.py
@@ -1,0 +1,351 @@
+"""
+Defines classes for querying for information about the installed products.
+
+MIT License
+
+(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+import logging
+from pkg_resources import parse_version
+import warnings
+
+from jsonschema.exceptions import ValidationError
+from kubernetes.client import CoreV1Api
+from kubernetes.client.rest import ApiException
+from kubernetes.config import load_kube_config, ConfigException
+from urllib3.exceptions import MaxRetryError
+from yaml import safe_load, YAMLError, YAMLLoadWarning
+
+from cray_product_catalog.constants import (
+    COMPONENT_DOCKER_KEY,
+    COMPONENT_REPOS_KEY,
+    COMPONENT_VERSIONS_PRODUCT_MAP_KEY,
+    PRODUCT_CATALOG_CONFIG_MAP_NAME,
+    PRODUCT_CATALOG_CONFIG_MAP_NAMESPACE,
+    LATEST_VERSION_STRING
+)
+from cray_product_catalog.schema.validate import validate
+from cray_product_catalog.util import load_k8s
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ProductCatalogError(Exception):
+    """An error occurred reading or manipulating product installs."""
+    pass
+
+
+class ProductCatalog:
+    """A collection of installed product versions.
+
+    Attributes:
+        name (str): The product catalog Kubernetes config map name.
+        namespace (str): The product catalog Kubernetes config map namespace.
+        products ([InstalledProductVersion]): A list of installed product
+            versions.
+    """
+    @staticmethod
+    def _get_k8s_api():
+        """Load a Kubernetes CoreV1Api and return it.
+
+        Returns:
+            CoreV1Api: The Kubernetes API.
+
+        Raises:
+            ProductCatalogError: if there was an error loading the
+                Kubernetes configuration.
+        """
+        try:
+            with warnings.catch_warnings():
+                warnings.filterwarnings('ignore', category=YAMLLoadWarning)
+                load_k8s()
+            return CoreV1Api()
+        except ConfigException as err:
+            raise ProductCatalogError(f'Unable to load kubernetes configuration: {err}.')
+
+    def __init__(self, name=PRODUCT_CATALOG_CONFIG_MAP_NAME, namespace=PRODUCT_CATALOG_CONFIG_MAP_NAMESPACE):
+        """Create the ProductCatalog object.
+
+        Args:
+            name (str): The name of the product catalog Kubernetes config map.
+            namespace (str): The namespace of the product catalog Kubernetes
+                config map.
+
+        Raises:
+            ProductCatalogError: if reading the config map failed.
+        """
+        self.name = name
+        self.namespace = namespace
+        self.k8s_client = self._get_k8s_api()
+        try:
+            config_map = self.k8s_client.read_namespaced_config_map(name, namespace)
+        except MaxRetryError as err:
+            raise ProductCatalogError(
+                f'Unable to connect to Kubernetes to read {namespace}/{name} ConfigMap: {err}'
+            )
+        except ApiException as err:
+            # The full string representation of ApiException is very long, so just log err.reason.
+            raise ProductCatalogError(
+                f'Error reading {namespace}/{name} ConfigMap: {err.reason}'
+            )
+
+        if config_map.data is None:
+            raise ProductCatalogError(
+                f'No data found in {namespace}/{name} ConfigMap.'
+            )
+
+        try:
+            self.products = [
+                InstalledProductVersion(product_name, product_version, product_version_data)
+                for product_name, product_versions in config_map.data.items()
+                for product_version, product_version_data in safe_load(product_versions).items()
+            ]
+        except YAMLError as err:
+            raise ProductCatalogError(
+                f'Failed to load ConfigMap data: {err}'
+            )
+
+        invalid_products = [
+            str(p) for p in self.products if not p.is_valid
+        ]
+        if invalid_products:
+            LOGGER.debug(
+                f'The following products have product catalog data that '
+                f'is not valid against the expected schema: {", ".join(invalid_products)}'
+            )
+
+        self.products = [
+            p for p in self.products if p.is_valid
+        ]
+
+    def get_product(self, name, version):
+        """Get the InstalledProductVersion matching the given name/version.
+
+        Args:
+            name (str): The product name.
+            version (str): The product version. If this is the special value
+                `LATEST_VERSION_STRING`, then get the latest installed version.
+
+        Returns:
+            An InstalledProductVersion with the given name and version.
+
+        Raises:
+            ProductCatalogError: If there is more than one matching
+                InstalledProductVersion, or if there are none.
+        """
+        if version == LATEST_VERSION_STRING:
+            matching_name_products = [product for product in self.products if product.name == name]
+            if not matching_name_products:
+                raise ProductCatalogError(f'No installed products with name {name}.')
+            latest = sorted(matching_name_products,
+                            key=lambda p: parse_version(p.version))[-1]
+            LOGGER.info(f'Using latest version ({latest.version}) of product {name}')
+            return latest
+
+        matching_products = [
+            product for product in self.products
+            if product.name == name and product.version == version
+        ]
+        if not matching_products:
+            raise ProductCatalogError(
+                f'No installed products with name {name} and version {version}.'
+            )
+        elif len(matching_products) > 1:
+            raise ProductCatalogError(
+                f'Multiple installed products with name {name} and version {version}.'
+            )
+
+        return matching_products[0]
+
+
+class InstalledProductVersion:
+    """A representation of a version of a product that is currently installed.
+
+    Attributes:
+        name (str): The product name.
+        version (str): The product version.
+        data (dict): A dictionary representing the data within a given product and
+            version in the product catalog, which is expected to contain a
+            'component_versions' key that will point to the respective
+            versions of product components, e.g. Docker images.
+    """
+    def __init__(self, name, version, data):
+        self.name = name
+        self.version = version
+        self.data = data
+
+    def __str__(self):
+        return f'{self.name}-{self.version}'
+
+    @property
+    def is_valid(self):
+        """bool: True if this product's version data fits the schema."""
+        try:
+            validate(self.data)
+            return True
+        except ValidationError:
+            return False
+
+    @property
+    def component_data(self):
+        """dict: a mapping from types of components to lists of components"""
+        return self.data.get(COMPONENT_VERSIONS_PRODUCT_MAP_KEY, {})
+
+    @property
+    def docker_images(self):
+        """Get Docker images associated with this InstalledProductVersion.
+
+        Returns:
+            A list of tuples of (image_name, image_version)
+        """
+        # If there is no 'docker' key under the component data, assume that there
+        # is a single docker image named cray/cray-PRODUCT whose version is the
+        # value of the PRODUCT key under component_versions.
+        if COMPONENT_DOCKER_KEY not in self.component_data:
+            return [(self._deprecated_docker_image_name, self._deprecated_docker_image_version)]
+
+        return [(component['name'], component['version'])
+                for component in self.component_data.get(COMPONENT_DOCKER_KEY) or []]
+
+    @property
+    def _deprecated_docker_image_version(self):
+        """str: The Docker image version associated with this product version, or None.
+
+        Note: this assumes that the 'component_versions' data is structured as follows:
+        component_versions:
+            product_name: docker_image_version
+
+        Newer versions will structure the 'component_versions' data as follows:
+        component_versions:
+            product_name:
+                docker:
+                    docker_image_name_1: docker_image_version
+                    docker_image_name_2: docker_image_version
+
+        This method should only be used if the installed version does not have a
+        component_versions->product_name->docker key.
+        """
+        return self.component_data.get(self.name)
+
+    @property
+    def _deprecated_docker_image_name(self):
+        """str: The Docker image name associated with this product version.
+
+        Note: this assumes that the 'component_versions' data is structured as follows:
+        component_versions:
+            product_name: docker_image_version
+
+        It also assumes that the name of the singular docker image is
+        'cray/cray-<product_name'.
+
+        Newer versions will structure the 'component_versions' data as follows:
+        component_versions:
+            product_name:
+                docker:
+                    docker_image_name_1: docker_image_version
+                    docker_image_name_2: docker_image_version
+
+        This method should only be used if the installed version does not have a
+        component_versions->product_name->docker key.
+        """
+        return f'cray/cray-{self.name}'
+
+    @property
+    def repositories(self):
+        """list of dict: the repositories for this product version."""
+        return self.component_data.get(COMPONENT_REPOS_KEY, [])
+
+    @property
+    def group_repositories(self):
+        """list of dict: the group-type repositories for this product version."""
+        return [repo for repo in self.repositories if repo.get('type') == 'group']
+
+    @property
+    def hosted_repositories(self):
+        """list of dict: the hosted-type repositories for this product version."""
+        return [repo for repo in self.repositories if repo.get('type') == 'hosted']
+
+    @property
+    def hosted_and_member_repo_names(self):
+        """set of str: all hosted repository names for this product version
+
+        This includes all explicitly listed hosted repos plus any hosted repos
+        which are listed only as members of any of the group repos
+        """
+        # Get all hosted repositories, plus any repos that might be under a group repo's "members" list.
+        repository_names = set(repo.get('name') for repo in self.hosted_repositories)
+        for group_repo in self.group_repositories:
+            repository_names |= set(group_repo.get('members'))
+
+        return repository_names
+
+    @property
+    def configuration(self):
+        """dict: information about the config management repo for the product"""
+        return self.data.get('configuration', {})
+
+    @property
+    def clone_url(self):
+        """str or None: the clone url of the config repo for the product, if available."""
+        return self.configuration.get('clone_url')
+
+    @property
+    def commit(self):
+        """str or None: the commit hash of the config repo for the product, if available."""
+        return self.configuration.get('commit')
+
+    @property
+    def import_branch(self):
+        """str or None: the branch name of the config repo for the product, if available."""
+        return self.configuration.get('import_branch')
+
+    def _get_ims_resources(self, ims_resource_type):
+        """Get IMS resources (images or recipes) provided by the product
+
+        Args:
+            ims_resource_type (str): Either 'images' or 'recipes'
+
+        Returns:
+            list of dict: the IMS resources of the given type provided by the
+                product. Each has a 'name' and 'id' key.
+
+        Raises:
+            ValueError: if given an unrecognized `ims_resource_type`
+        """
+        if ims_resource_type not in ('recipes', 'images'):
+            raise ValueError(f'Unrecognized IMS resource type "{ims_resource_type}"')
+
+        ims_resource_data = self.data.get(ims_resource_type) or {}
+
+        return [
+            {'name': resource_name, 'id': resource_data.get('id')}
+            for resource_name, resource_data in ims_resource_data.items()
+        ]
+
+    @property
+    def images(self):
+        """list of dict: the list of images provided by this product"""
+        return self._get_ims_resources('images')
+
+    @property
+    def recipes(self):
+        return self._get_ims_resources('recipes')

--- a/cray_product_catalog/util.py
+++ b/cray_product_catalog/util.py
@@ -1,0 +1,34 @@
+"""
+Defines utility functions used by other modules.
+
+MIT License
+
+(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+"""
+from kubernetes import config
+
+
+def load_k8s():
+    """ Load Kubernetes Configuration """
+    try:
+        config.load_incluster_config()
+    except Exception:
+        config.load_kube_config()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 jsonschema
 kubernetes
 pyyaml
+urllib3

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,0 +1,137 @@
+"""
+Mock data for ProductCatalog and InstalledProductVersion unit tests
+
+(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+from yaml import safe_dump
+
+
+# Two versions of a product named SAT where:
+# - The two versions have have no docker images in common with one another.
+# - Both have configurations, but neither have images or recipes
+SAT_VERSIONS = {
+    '2.0.0': {
+        'component_versions': {
+            'docker': [
+                {'name': 'cray/cray-sat', 'version': '1.0.0'},
+                {'name': 'cray/sat-cfs-install', 'version': '1.4.0'}
+            ],
+            'repositories': [
+                {'name': 'sat-sle-15sp2', 'type': 'group', 'members': ['sat-2.0.0-sle-15sp2']},
+                {'name': 'sat-2.0.0-sle-15sp2', 'type': 'hosted'}
+            ]
+        },
+        "configuration": {
+           "clone_url": "https://vcs.machine.dev.cray.com/vcs/cray/sat-config-management.git",
+           "commit": "5b7e74714c7f789e474ac9dbc2cae5c04d0e8e33",
+           "import_branch": "cray/sat/2.0.0",
+           "import_date": "2021-07-07T22:13:32.462655Z",
+           "ssh_url": "git@vcs.machine.dev.cray.com:cray/sat-config-management.git"
+        }
+    },
+    '2.0.1': {
+        'component_versions': {
+            'docker': [
+                {'name': 'cray/cray-sat', 'version': '1.0.1'},
+                {'name': 'cray/sat-other-image', 'version': '1.4.0'}
+            ],
+            'repositories': [
+                {'name': 'sat-sle-15sp2', 'type': 'group', 'members': ['sat-2.0.1-sle-15sp2']},
+                {'name': 'sat-2.0.1-sle-15sp2', 'type': 'hosted'}
+            ]
+        },
+        "configuration": {
+            "clone_url": "https://vcs.machine.dev.cray.com/vcs/cray/sat-config-management.git",
+            "commit": "e1fa10b6865fb47ced6c1a6cfab2bc28fe149a74",
+            "import_branch": "cray/sat/2.0.1",
+            "import_date": "2021-10-26T15:23:06.078295Z",
+            "ssh_url": "git@vcs.machine.dev.cray.com:cray/sat-config-management.git"
+        }
+    },
+}
+
+# Two versions of a product named COS where:
+# - The two versions have one docker image name and version in common
+# - The first version has no repositories, configuration, images, or recipes
+# - The second version has repositories, configuration, images, and recipes
+COS_VERSIONS = {
+    '2.0.0': {
+        'component_versions': {
+            'docker': [
+                {'name': 'cray/cray-cos', 'version': '1.0.0'},
+                {'name': 'cray/cos-cfs-install', 'version': '1.4.0'}
+            ]
+        }
+    },
+    '2.0.1': {
+        'component_versions': {
+            'docker': [
+                {'name': 'cray/cray-cos', 'version': '1.0.1'},
+                {'name': 'cray/cos-cfs-install', 'version': '1.4.0'}
+            ],
+            'repositories': [
+                {'name': 'cos-sle-15sp2', 'type': 'group', 'members': ['cos-2.0.1-sle-15sp2']},
+                {'name': 'cos-2.0.1-sle-15sp2', 'type': 'hosted'}
+            ]
+        },
+        "configuration": {
+            "clone_url": "https://vcs.machine.dev.cray.com/vcs/cray/cos-config-management.git",
+            "commit": "f0b17e13fcf7dd3b896196776e4547fdb98f1da7",
+            "import_branch": "cray/cos/2.0.1",
+            "import_date": "2021-11-24T12:04:25.210495Z",
+            "ssh_url": "git@vcs.machine.dev.cray.com:cray/cos-config-management.git"
+        },
+        "images": {
+            "cray-shasta-compute-sles15sp2.x86_64-1.5.66": {
+                "id": "e2d58d7e-42b7-434d-b689-31ca3d053c51"
+            }
+        },
+        "recipes": {
+            "cray-shasta-compute-sles15sp2.x86_64-1.5.66": {
+                "id": "54bc9447-73ba-4b06-a647-e5225451596d"
+            }
+        }
+    },
+}
+
+# One version of "Other Product" that also uses cray/cray-sat:1.0.1
+OTHER_PRODUCT_VERSION = {
+    '2.0.0': {
+        'component_versions': {
+            'docker': [
+                {'name': 'cray/cray-sat', 'version': '1.0.1'},
+            ],
+            'repositories': [
+                {'name': 'sat-sle-15sp2', 'type': 'group', 'members': ['sat-2.0.0-sle-15sp2']},
+                {'name': 'sat-2.0.0-sle-15sp2', 'type': 'hosted'}
+            ]
+        }
+    }
+}
+
+
+# A mock version of the data returned when querying the Product Catalog ConfigMap
+MOCK_PRODUCT_CATALOG_DATA = {
+    'sat': safe_dump(SAT_VERSIONS),
+    'cos': safe_dump(COS_VERSIONS),
+    'other_product': safe_dump(OTHER_PRODUCT_VERSION)
+}

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,312 @@
+"""
+Unit tests for sat.software_inventory.products module
+
+(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+import copy
+import logging
+import unittest
+from unittest.mock import Mock, patch
+
+from kubernetes.config import ConfigException
+from yaml import safe_dump
+
+from cray_product_catalog.constants import LATEST_VERSION_STRING
+from cray_product_catalog.query import (
+    ProductCatalog,
+    InstalledProductVersion,
+    ProductCatalogError
+)
+from tests.mocks import COS_VERSIONS, MOCK_PRODUCT_CATALOG_DATA, SAT_VERSIONS
+
+
+class TestGetK8sAPI(unittest.TestCase):
+    """Tests for ProductCatalog.get_k8s_api()."""
+
+    def setUp(self):
+        """Set up mocks."""
+        self.mock_load_k8s = patch('cray_product_catalog.query.load_k8s').start()
+        self.mock_corev1api = patch('cray_product_catalog.query.CoreV1Api').start()
+
+    def tearDown(self):
+        """Stop patches."""
+        patch.stopall()
+
+    def test_get_k8s_api(self):
+        """Test the successful case of get_k8s_api."""
+        api = ProductCatalog._get_k8s_api()
+        self.mock_load_k8s.assert_called_once_with()
+        self.mock_corev1api.assert_called_once_with()
+        self.assertEqual(api, self.mock_corev1api.return_value)
+
+    def test_get_k8s_api_config_exception(self):
+        """Test when configuration can't be loaded."""
+        self.mock_load_k8s.side_effect = ConfigException
+        with self.assertRaises(ProductCatalogError):
+            ProductCatalog._get_k8s_api()
+        self.mock_load_k8s.assert_called_once_with()
+        self.mock_corev1api.assert_not_called()
+
+
+class TestProductCatalog(unittest.TestCase):
+    """Tests for the ProductCatalog class."""
+
+    def setUp(self):
+        """Set up mocks."""
+        self.mock_k8s_api = patch.object(ProductCatalog, '_get_k8s_api').start().return_value
+        self.mock_product_catalog_data = copy.deepcopy(MOCK_PRODUCT_CATALOG_DATA)
+        self.mock_k8s_api.read_namespaced_config_map.return_value = Mock(data=self.mock_product_catalog_data)
+
+    def tearDown(self):
+        """Stop patches."""
+        patch.stopall()
+
+    def create_and_assert_product_catalog(self):
+        """Assert the product catalog was created as expected."""
+        product_catalog = ProductCatalog('mock-name', 'mock-namespace')
+        self.mock_k8s_api.read_namespaced_config_map.assert_called_once_with('mock-name', 'mock-namespace')
+        return product_catalog
+
+    def test_create_product_catalog(self):
+        """Test creating a simple ProductCatalog."""
+        product_catalog = self.create_and_assert_product_catalog()
+        expected_names_and_versions = [
+            (name, version) for name in ('sat', 'cos') for version in ('2.0.0', '2.0.1')
+        ] + [('other_product', '2.0.0')]
+        actual_names_and_versions = [
+            (product.name, product.version) for product in product_catalog.products
+        ]
+        self.assertEqual(expected_names_and_versions, actual_names_and_versions)
+
+    def test_create_product_catalog_invalid_product_data(self):
+        """Test creating a ProductCatalog when the product catalog contains invalid YAML."""
+        self.mock_product_catalog_data['sat'] = '\t'
+        with self.assertRaisesRegex(ProductCatalogError, 'Failed to load ConfigMap data'):
+            self.create_and_assert_product_catalog()
+
+    def test_create_product_catalog_null_data(self):
+        """Test creating a ProductCatalog when the product catalog contains null data."""
+        self.mock_k8s_api.read_namespaced_config_map.return_value = Mock(data=None)
+        with self.assertRaisesRegex(ProductCatalogError,
+                                    'No data found in mock-namespace/mock-name ConfigMap.'):
+            self.create_and_assert_product_catalog()
+
+    def test_create_product_catalog_invalid_product_schema(self):
+        """Test creating a ProductCatalog when an entry contains valid YAML but does not match schema."""
+        self.mock_k8s_api.read_namespaced_config_map.return_value = Mock(data={
+            'sat': safe_dump({'2.1': {'this_key_is_not_allowed': {}}})
+        })
+        with self.assertLogs(level=logging.DEBUG) as logs_cm:
+            product_catalog = self.create_and_assert_product_catalog()
+
+        self.assertEqual(1, len(logs_cm.records))
+        self.assertEqual('The following products have product catalog data that '
+                         'is not valid against the expected schema: sat-2.1',
+                         logs_cm.records[0].message)
+        self.assertEqual(product_catalog.products, [])
+
+    def test_get_matching_product(self):
+        """Test getting a particular product by name/version."""
+        product_catalog = self.create_and_assert_product_catalog()
+        expected_matching_name_and_version = ('cos', '2.0.0')
+        actual_matching_product = product_catalog.get_product('cos', '2.0.0')
+        self.assertEqual(
+            expected_matching_name_and_version, (actual_matching_product.name, actual_matching_product.version)
+        )
+        expected_component_data = COS_VERSIONS['2.0.0']
+        self.assertEqual(expected_component_data, actual_matching_product.data)
+
+    def test_get_latest_matching_product(self):
+        """Test getting the latest version of a product"""
+        product_catalog = self.create_and_assert_product_catalog()
+        expected_matching_name_and_version = ('sat', '2.0.1')
+        actual_matching_product = product_catalog.get_product('sat', LATEST_VERSION_STRING)
+        self.assertEqual(expected_matching_name_and_version,
+                         (actual_matching_product.name, actual_matching_product.version))
+        expected_component_data = SAT_VERSIONS['2.0.1']
+        self.assertEqual(expected_component_data, actual_matching_product.data)
+
+
+class TestInstalledProductVersion(unittest.TestCase):
+    """Tests for the InstalledProductVersion class."""
+    def setUp(self):
+        """Create an InstalledProductVersion object to test"""
+        # Use this product version because its data is most complete
+        self.installed_product_version = InstalledProductVersion(
+            'cos', '2.0.1', COS_VERSIONS['2.0.1']
+        )
+
+    def tearDown(self):
+        """Stop patches."""
+        patch.stopall()
+
+    def test_docker_images(self):
+        """Test getting the Docker images."""
+        expected_docker_image_versions = [('cray/cray-cos', '1.0.1'),
+                                          ('cray/cos-cfs-install', '1.4.0')]
+        self.assertEqual(
+            expected_docker_image_versions, self.installed_product_version.docker_images
+        )
+
+    def test_legacy_docker_images(self):
+        """Test getting the Docker images from an 'old'-style product catalog entry."""
+        legacy_installed_product_version = InstalledProductVersion(
+            'sat', '1.0.1', {'component_versions': {'sat': '1.0.0'}}
+        )
+        expected_docker_image_versions = [('cray/cray-sat', '1.0.0')]
+        self.assertEqual(
+            expected_docker_image_versions, legacy_installed_product_version.docker_images
+        )
+
+    def test_no_docker_images(self):
+        """Test a product that has an empty dictionary under the 'docker' key returns an empty dictionary."""
+        product_with_no_docker_images = InstalledProductVersion(
+            'sat', '0.9.9', {'component_versions': {'docker': {}}}
+        )
+        self.assertEqual(product_with_no_docker_images.docker_images, [])
+
+    def test_no_docker_images_null(self):
+        """Test a product that has None under the 'docker' key returns an empty dictionary."""
+        product_with_no_docker_images = InstalledProductVersion(
+            'sat', '0.9.9', {'component_versions': {'docker': None}}
+        )
+        self.assertEqual(product_with_no_docker_images.docker_images, [])
+
+    def test_no_docker_images_empty_list(self):
+        """Test a product that has an empty list under the 'docker' key returns an empty dictionary."""
+        product_with_no_docker_images = InstalledProductVersion(
+            'sat', '0.9.9', {'component_versions': {'docker': []}}
+        )
+        self.assertEqual(product_with_no_docker_images.docker_images, [])
+
+    def test_str(self):
+        """Test the string representation of InstalledProductVersion."""
+        expected_str = 'cos-2.0.1'
+        self.assertEqual(
+            expected_str, str(self.installed_product_version)
+        )
+
+    def test_group_repos(self):
+        """Test getting group repo data for an InstalledProductVersion."""
+        expected_group_repos = [{'members': ['cos-2.0.1-sle-15sp2'], 'name': 'cos-sle-15sp2', 'type': 'group'}]
+        self.assertEqual(
+            expected_group_repos, self.installed_product_version.group_repositories
+        )
+
+    def test_hosted_repos(self):
+        """Test getting hosted repo names for an InstalledProductVersion."""
+        expected_hosted_repo_names = {'cos-2.0.1-sle-15sp2'}
+        self.assertEqual(
+            expected_hosted_repo_names, self.installed_product_version.hosted_and_member_repo_names
+        )
+
+    def test_hosted_repos_without_members(self):
+        """Test getting hosted repo names that are listed only as hosted repos but not a member of a group."""
+        sat_version_data = copy.deepcopy(SAT_VERSIONS['2.0.0'])
+        sat_version_data['component_versions']['repositories'] = [
+            {'name': 'my-hosted-repo', 'type': 'hosted'}
+        ]
+        ipv = InstalledProductVersion('sat', '2.0.0', sat_version_data)
+        expected_hosted_repo_names = {'my-hosted-repo'}
+        self.assertEqual(ipv.hosted_and_member_repo_names, expected_hosted_repo_names)
+
+    def test_hosted_repos_only_members(self):
+        """Test getting hosted repo names that are not listed except as a member of a group."""
+        sat_version_data = copy.deepcopy(SAT_VERSIONS['2.0.0'])
+        sat_version_data['component_versions']['repositories'] = [
+            {'name': 'my-group-repo', 'type': 'group', 'members': ['my-hosted-repo']}
+        ]
+        ipv = InstalledProductVersion('sat', '2.0.0', sat_version_data)
+        expected_hosted_repo_names = {'my-hosted-repo'}
+        self.assertEqual(ipv.hosted_and_member_repo_names, expected_hosted_repo_names)
+
+    def test_configuration_items_present(self):
+        """Test getting configuration values when the product includes them."""
+        attr_and_expected_val = [
+            ('clone_url', 'https://vcs.machine.dev.cray.com/vcs/cray/cos-config-management.git'),
+            ('commit', 'f0b17e13fcf7dd3b896196776e4547fdb98f1da7'),
+            ('import_branch', 'cray/cos/2.0.1')
+        ]
+        for attr, expected_val in attr_and_expected_val:
+            with self.subTest(attr=attr):
+                self.assertEqual(expected_val, getattr(self.installed_product_version, attr))
+
+    def test_configuration_items_missing(self):
+        """Test getting configuration values when the product does not include them in its configuration data."""
+        attrs = ['clone_url', 'commit', 'import_branch']
+        for attr in attrs:
+            with self.subTest(attr=attr):
+                cos_version_data = copy.deepcopy(COS_VERSIONS['2.0.1'])
+                del cos_version_data['configuration'][attr]
+                ipv = InstalledProductVersion('cos', '2.0.1', cos_version_data)
+                self.assertIsNone(getattr(ipv, attr))
+
+    def test_configuration_missing(self):
+        """Test getting configuration values when the product does not include any configuration data."""
+        attrs = ['clone_url', 'commit', 'import_branch']
+        cos_version_data = copy.deepcopy(COS_VERSIONS['2.0.1'])
+        del cos_version_data['configuration']
+        ipv = InstalledProductVersion('cos', '2.0.1', cos_version_data)
+        for attr in attrs:
+            with self.subTest(attr=attr):
+                self.assertIsNone(getattr(ipv, attr))
+
+    def test_recipes(self):
+        """Test getting recipes when the product has one."""
+        expected_recipes = [{'name': 'cray-shasta-compute-sles15sp2.x86_64-1.5.66',
+                             'id': '54bc9447-73ba-4b06-a647-e5225451596d'}]
+        self.assertEqual(expected_recipes, self.installed_product_version.recipes)
+
+    def test_images(self):
+        """Test getting images when the product has one."""
+        expected_images = [{'name': 'cray-shasta-compute-sles15sp2.x86_64-1.5.66',
+                            'id': 'e2d58d7e-42b7-434d-b689-31ca3d053c51'}]
+        self.assertEqual(expected_images, self.installed_product_version.images)
+
+    def test_ims_resources_missing(self):
+        """Test getting recipes/images when the product has no corresponding key in its data."""
+        ipv = InstalledProductVersion('sat', '2.0.0', SAT_VERSIONS['2.0.0'])
+        for attr in ['recipes', 'images']:
+            with self.subTest(attr=attr):
+                self.assertEqual([], getattr(ipv, attr))
+
+    def test_ims_resources_null(self):
+        """Test getting recipes/images when the product has a null value for the corresponding key."""
+        for attr in ['recipes', 'images']:
+            sat_version_data = copy.deepcopy(SAT_VERSIONS['2.0.0'])
+            sat_version_data[attr] = None
+            ipv = InstalledProductVersion('sat', '2.0.0', sat_version_data)
+            with self.subTest(attr=attr):
+                self.assertEqual([], getattr(ipv, attr))
+
+    def test_ims_resources_empty(self):
+        """Test getting recipes/images when the product has an empty dict value for the corresponding key."""
+        for attr in ['recipes', 'images']:
+            sat_version_data = copy.deepcopy(SAT_VERSIONS['2.0.0'])
+            sat_version_data[attr] = {}
+            ipv = InstalledProductVersion('sat', '2.0.0', sat_version_data)
+            with self.subTest(attr=attr):
+                self.assertEqual([], getattr(ipv, attr))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary and Scope

This adds a new module, `query.py`, which clients can use to query the `cray-product-catalog` Kubernetes ConfigMap to get information about the products installed on the system.

This new module is not exposed as an executable script in the Docker image like `catalog_update` and `catalog_delete`. Rather, it is meant to be used as a library in other Python projects.

This repository is a logical place for such a library because the query code must validate the product catalog data against the schema before processing, and this repository already contains the schema definition and validation code.

The `catalog_update` and `catalog_delete` scripts are mostly unaffected. One minor change was made to define the `load_k8s` function in a common `util` module since it is now used in 3 places.

This change is backwards compatible. Existing users of the `catalog_update` and `catalog_delete` scripts are not affected.

## Issues and Related PRs

* Resolves [CRAYSAT-1314](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1314)

## Testing

### Tested on:

* Unit tests have been run in a local Python virtualenv on my macbook.
* Testing in a Python virtualenv occurred on baldar.

### Test description:

New unit tests have been added.

Tested by installing into a Python virtualenv on baldar and running a script which used the `ProductCatalog` class to print information about installed versions of products.

Still need to test by running `catalog_update` in the container with `podman` to ensure that products that update the product catalog data like this still work.

Still need to test by deploying a K8s job that updates the product catalog by calling catalog_update.py.

Would also like to test by deploying a job in K8s that runs a single python command to get installed versions of the SAT product to ensure that the `load_k8s` function works as expected to load the K8s config while running in a K8s pod. This is not an expected usage scenario, but it would be good to know the code works as expected.
_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

## Risks and Mitigations

Risk should be minimal as this mostly adds new code that can be used by other Python projects.

## Pull Request Checklist

- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] Is a new version being released? Update https://github.com/Cray-HPE/cray-product-catalog/wiki/CSM-Compatibility-Matrix
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
