### PR TITLE
CASMCMS-7995: Fix the Artifactory upload paths

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -246,8 +246,8 @@ jobs:
           PYMOD_VERSION: ${{ needs.build-prep.outputs.py-version }}
         run: |
           ls -lRa dist/
-          jfrog rt upload "dist/*.tar.gz" "${PYMOD_REPOSITORY}/simple/${PYMOD_NAME}/"
-          jfrog rt upload "dist/*.whl" "${PYMOD_REPOSITORY}/simple/${PYMOD_NAME}/"
+          jfrog rt upload --flat=true "dist/*.tar.gz" "${PYMOD_REPOSITORY}/simple/${PYMOD_NAME}/"
+          jfrog rt upload --flat=true "dist/*.whl" "${PYMOD_REPOSITORY}/simple/${PYMOD_NAME}/"
 
       - name: Upload Python Module as Build Artifact
         uses: actions/upload-artifact@v2
@@ -574,7 +574,7 @@ jobs:
           CHARTS_PATTERN: "*.tgz"
           CHART_VERSION: ${{ needs.build-prep.outputs.chart-version }}
         run: |
-          jfrog rt upload "charts/.packaged/${CHART_NAME}-${CHART_VERSION}.tgz" "${CHART_REPOSITORY}/${STABLE_PATH}/${CHART_NAME}/"
+          jfrog rt upload --flat=true "charts/.packaged/${CHART_NAME}-${CHART_VERSION}.tgz" "${CHART_REPOSITORY}/${STABLE_PATH}/${CHART_NAME}/"
 
           # Provide links for downloading
           for packaged_chart in $(find charts/.packaged -mindepth 1 -maxdepth 1); do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
 - Update license text to comply with automatic license-check tool.
 
 - Update deploy script to work with CSM 1.2 systems and Nexus authentication
+
+### Fixed
+
+- Fixed location where Python module and Helm chart are published to
+  Artifactory by "Build Artifacts" GitHub Actions workflow.
 
 ## [1.5.5] - 2022-03-04
 


### PR DESCRIPTION
## Summary and Scope

In v2 of the `jfrog` CLI, the default value for the `--flat` option changed from true to false. If `--flat` is true, then files are uploaded to the exact target path and their location in the source file system is ignored. If `--flat` is false, then files are uploaded to a target that includes their parent directories on the source file system.

This was resulting in Python modules and helm charts being uploaded into an incorrect location. For example, Python module archives and wheels were uploaded to a `dist` subdirectory in the pip repository and thus could not be found by `pip`.

Fix this problem by specifying `--flat true` on `jfrog rt upload` calls to keep the prior behavior.

## Issues and Related PRs

* Resolves [CASMCMS-7995](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7995)

## Testing

### Tested on:

* GitHub Actions
* Local python package install

### Test description:

Examined artifactory to see that helm charts and python modules get published in the expected locations.  Checked that I could install the new version of the python module with `pip`.

## Risks and Mitigations

No known risks. Fixes a build publishing problem.


## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Is a new version being released? Update https://github.com/Cray-HPE/cray-product-catalog/wiki/CSM-Compatibility-Matrix
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

