### PR TITLE
CRAYSAT-1314: Add product catalog query module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added new `query` module to query the `cray-product-catalog` K8s ConfigMap to
+  obtain information about the installed products.
+
 ### Changed
 
 - Update base image to artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Relaxed schema for product data added to `cray-product-catalog` K8s ConfigMap
+  to allow additional properties.
+
 - Update base image to artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.15
 
 - Update license text to comply with automatic license-check tool.

--- a/cray_product_catalog/catalog_delete.py
+++ b/cray_product_catalog/catalog_delete.py
@@ -46,11 +46,13 @@ import time
 import urllib3
 from urllib3.util.retry import Retry
 
-from kubernetes import client, config
+from kubernetes import client
 from kubernetes.client.api_client import ApiClient
 from kubernetes.client.configuration import Configuration
 from kubernetes.client.rest import ApiException
 import yaml
+
+from cray_product_catalog.util import load_k8s
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -60,14 +62,6 @@ LOGGER.setLevel(logging.INFO)
 handler = logging.StreamHandler(sys.stdout)
 handler.setLevel(logging.DEBUG)
 LOGGER.addHandler(handler)
-
-
-def load_k8s():
-    """ Load Kubernetes Configuration """
-    try:
-        config.load_incluster_config()
-    except Exception:
-        config.load_kube_config()
 
 
 def modify_config_map(name, namespace, product, product_version, key=None):

--- a/cray_product_catalog/catalog_update.py
+++ b/cray_product_catalog/catalog_update.py
@@ -40,13 +40,14 @@ import urllib3
 from urllib3.util.retry import Retry
 
 from jsonschema.exceptions import ValidationError
-from kubernetes import client, config
+from kubernetes import client
 from kubernetes.client.api_client import ApiClient
 from kubernetes.client.configuration import Configuration
 from kubernetes.client.rest import ApiException
 import yaml
 
 from cray_product_catalog.schema.validate import validate
+from cray_product_catalog.util import load_k8s
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -65,14 +66,6 @@ CONFIG_MAP_NAMESPACE = os.environ.get("CONFIG_MAP_NAMESPACE", "services").strip(
 YAML_CONTENT = os.environ.get("YAML_CONTENT").strip()  # required
 SET_ACTIVE_VERSION = bool(os.environ.get("SET_ACTIVE_VERSION"))
 VALIDATE_SCHEMA = bool(os.environ.get("VALIDATE_SCHEMA"))
-
-
-def load_k8s():
-    """ Load Kubernetes Configuration """
-    try:
-        config.load_incluster_config()
-    except Exception:
-        config.load_kube_config()
 
 
 def validate_schema(data):

--- a/cray_product_catalog/constants.py
+++ b/cray_product_catalog/constants.py
@@ -20,14 +20,10 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# Defines utility functions used by other modules.
+# Defines constants used when querying the product catalog.
 
-from kubernetes import config
-
-
-def load_k8s():
-    """ Load Kubernetes Configuration """
-    try:
-        config.load_incluster_config()
-    except Exception:
-        config.load_kube_config()
+PRODUCT_CATALOG_CONFIG_MAP_NAME = 'cray-product-catalog'
+PRODUCT_CATALOG_CONFIG_MAP_NAMESPACE = 'services'
+COMPONENT_VERSIONS_PRODUCT_MAP_KEY = 'component_versions'
+COMPONENT_REPOS_KEY = 'repositories'
+COMPONENT_DOCKER_KEY = 'docker'

--- a/cray_product_catalog/query.py
+++ b/cray_product_catalog/query.py
@@ -1,0 +1,305 @@
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Defines classes for querying for information about the installed products.
+import logging
+from pkg_resources import parse_version
+
+from jsonschema.exceptions import ValidationError
+from kubernetes.client import CoreV1Api
+from kubernetes.client.rest import ApiException
+from kubernetes.config import ConfigException
+from urllib3.exceptions import MaxRetryError
+from yaml import safe_load, YAMLError
+
+from cray_product_catalog.constants import (
+    COMPONENT_DOCKER_KEY,
+    COMPONENT_REPOS_KEY,
+    COMPONENT_VERSIONS_PRODUCT_MAP_KEY,
+    PRODUCT_CATALOG_CONFIG_MAP_NAME,
+    PRODUCT_CATALOG_CONFIG_MAP_NAMESPACE,
+)
+from cray_product_catalog.schema.validate import validate
+from cray_product_catalog.util import load_k8s
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ProductCatalogError(Exception):
+    """An error occurred reading or manipulating product installs."""
+    pass
+
+
+class ProductCatalog:
+    """A collection of installed product versions.
+
+    Attributes:
+        name (str): The product catalog Kubernetes config map name.
+        namespace (str): The product catalog Kubernetes config map namespace.
+        products ([InstalledProductVersion]): A list of installed product
+            versions.
+    """
+    @staticmethod
+    def _get_k8s_api():
+        """Load a Kubernetes CoreV1Api and return it.
+
+        Returns:
+            CoreV1Api: The Kubernetes API.
+
+        Raises:
+            ProductCatalogError: if there was an error loading the
+                Kubernetes configuration.
+        """
+        try:
+            load_k8s()
+            return CoreV1Api()
+        except ConfigException as err:
+            raise ProductCatalogError(f'Unable to load kubernetes configuration: {err}.')
+
+    def __init__(self, name=PRODUCT_CATALOG_CONFIG_MAP_NAME, namespace=PRODUCT_CATALOG_CONFIG_MAP_NAMESPACE):
+        """Create the ProductCatalog object.
+
+        Args:
+            name (str): The name of the product catalog Kubernetes config map.
+            namespace (str): The namespace of the product catalog Kubernetes
+                config map.
+
+        Raises:
+            ProductCatalogError: if reading the config map failed.
+        """
+        self.name = name
+        self.namespace = namespace
+        self.k8s_client = self._get_k8s_api()
+        try:
+            config_map = self.k8s_client.read_namespaced_config_map(name, namespace)
+        except MaxRetryError as err:
+            raise ProductCatalogError(
+                f'Unable to connect to Kubernetes to read {namespace}/{name} ConfigMap: {err}'
+            )
+        except ApiException as err:
+            # The full string representation of ApiException is very long, so just log err.reason.
+            raise ProductCatalogError(
+                f'Error reading {namespace}/{name} ConfigMap: {err.reason}'
+            )
+
+        if config_map.data is None:
+            raise ProductCatalogError(
+                f'No data found in {namespace}/{name} ConfigMap.'
+            )
+
+        try:
+            self.products = [
+                InstalledProductVersion(product_name, product_version, product_version_data)
+                for product_name, product_versions in config_map.data.items()
+                for product_version, product_version_data in safe_load(product_versions).items()
+            ]
+        except YAMLError as err:
+            raise ProductCatalogError(
+                f'Failed to load ConfigMap data: {err}'
+            )
+
+        invalid_products = [
+            str(p) for p in self.products if not p.is_valid
+        ]
+        if invalid_products:
+            LOGGER.debug(
+                f'The following products have product catalog data that '
+                f'is not valid against the expected schema: {", ".join(invalid_products)}'
+            )
+
+        self.products = [
+            p for p in self.products if p.is_valid
+        ]
+
+    def get_product(self, name, version=None):
+        """Get the InstalledProductVersion matching the given name/version.
+
+        Args:
+            name (str): The product name.
+            version (str, optional): The product version. If omitted or None,
+                get the latest installed version.
+
+        Returns:
+            An InstalledProductVersion with the given name and version.
+
+        Raises:
+            ProductCatalogError: If there is more than one matching
+                InstalledProductVersion, or if there are none.
+        """
+        if not version:
+            matching_name_products = [product for product in self.products if product.name == name]
+            if not matching_name_products:
+                raise ProductCatalogError(f'No installed products with name {name}.')
+            latest = sorted(matching_name_products,
+                            key=lambda p: parse_version(p.version))[-1]
+            LOGGER.debug(f'Using latest version ({latest.version}) of product {name}')
+            return latest
+
+        matching_products = [
+            product for product in self.products
+            if product.name == name and product.version == version
+        ]
+        if not matching_products:
+            raise ProductCatalogError(
+                f'No installed products with name {name} and version {version}.'
+            )
+        elif len(matching_products) > 1:
+            raise ProductCatalogError(
+                f'Multiple installed products with name {name} and version {version}.'
+            )
+
+        return matching_products[0]
+
+
+class InstalledProductVersion:
+    """A representation of a version of a product that is currently installed.
+
+    Attributes:
+        name (str): The product name.
+        version (str): The product version.
+        data (dict): A dictionary representing the data within a given product and
+            version in the product catalog, which is expected to contain a
+            'component_versions' key that will point to the respective
+            versions of product components, e.g. Docker images.
+    """
+    def __init__(self, name, version, data):
+        self.name = name
+        self.version = version
+        self.data = data
+
+    def __str__(self):
+        return f'{self.name}-{self.version}'
+
+    @property
+    def is_valid(self):
+        """bool: True if this product's version data fits the schema."""
+        try:
+            validate(self.data)
+            return True
+        except ValidationError:
+            return False
+
+    @property
+    def component_data(self):
+        """dict: a mapping from types of components to lists of components"""
+        return self.data.get(COMPONENT_VERSIONS_PRODUCT_MAP_KEY, {})
+
+    @property
+    def docker_images(self):
+        """Get Docker images associated with this InstalledProductVersion.
+
+        Returns:
+            A list of tuples of (image_name, image_version)
+        """
+        return [(component['name'], component['version'])
+                for component in self.component_data.get(COMPONENT_DOCKER_KEY) or []]
+
+    @property
+    def repositories(self):
+        """list of dict: the repositories for this product version."""
+        return self.component_data.get(COMPONENT_REPOS_KEY, [])
+
+    @property
+    def group_repositories(self):
+        """list of dict: the group-type repositories for this product version."""
+        return [repo for repo in self.repositories if repo.get('type') == 'group']
+
+    @property
+    def hosted_repositories(self):
+        """list of dict: the hosted-type repositories for this product version."""
+        return [repo for repo in self.repositories if repo.get('type') == 'hosted']
+
+    @property
+    def hosted_and_member_repo_names(self):
+        """set of str: all hosted repository names for this product version
+
+        This includes all explicitly listed hosted repos plus any hosted repos
+        which are listed only as members of any of the group repos
+        """
+        # Get all hosted repositories, plus any repos that might be under a group repo's "members" list.
+        repository_names = set(repo.get('name') for repo in self.hosted_repositories)
+        for group_repo in self.group_repositories:
+            repository_names |= set(group_repo.get('members'))
+
+        return repository_names
+
+    @property
+    def configuration(self):
+        """dict: information about the config management repo for the product"""
+        return self.data.get('configuration', {})
+
+    @property
+    def clone_url(self):
+        """str or None: the clone url of the config repo for the product, if available."""
+        return self.configuration.get('clone_url')
+
+    @property
+    def commit(self):
+        """str or None: the commit hash of the config repo for the product, if available."""
+        return self.configuration.get('commit')
+
+    @property
+    def import_branch(self):
+        """str or None: the branch name of the config repo for the product, if available."""
+        return self.configuration.get('import_branch')
+
+    def _get_ims_resources(self, ims_resource_type):
+        """Get IMS resources (images or recipes) provided by the product
+
+        Args:
+            ims_resource_type (str): Either 'images' or 'recipes'
+
+        Returns:
+            list of dict: the IMS resources of the given type provided by the
+                product. Each has a 'name' and 'id' key.
+
+        Raises:
+            ValueError: if given an unrecognized `ims_resource_type`
+        """
+        if ims_resource_type not in ('recipes', 'images'):
+            raise ValueError(f'Unrecognized IMS resource type "{ims_resource_type}"')
+
+        ims_resource_data = self.data.get(ims_resource_type) or {}
+
+        return [
+            {'name': resource_name, 'id': resource_data.get('id')}
+            for resource_name, resource_data in ims_resource_data.items()
+        ]
+
+    @property
+    def images(self):
+        """list of dict: the list of images provided by this product"""
+        return self._get_ims_resources('images')
+
+    @property
+    def recipes(self):
+        return self._get_ims_resources('recipes')
+
+    @property
+    def supports_active(self):
+        """bool: whether this product version indicates whether or not it is the active version"""
+        return 'active' in self.data
+
+    @property
+    def active(self):
+        """bool: whether or not this product is active"""
+        return self.data.get('active', False)

--- a/cray_product_catalog/schema/schema.yaml
+++ b/cray_product_catalog/schema/schema.yaml
@@ -31,7 +31,6 @@ description: >
   A schema that describes the structure of product catalog config map data
   for a particular product version.
 type: object
-additionalProperties: false
 minItems: 1
 properties:
   active:
@@ -43,13 +42,8 @@ properties:
     type: object
     oneOf:
       - description: >
-          A basic mapping of component name to version. This format is deprecated.
-        additionalProperties:
-          type: string
-      - description: >
           A mapping of component types to components of that type provided by a
           given version of the product.
-        additionalProperties: false
         properties:
           docker:
             $ref: '#/definitions/ComponentVersions'
@@ -66,7 +60,6 @@ properties:
   configuration:
     description: The data regarding this version's configuration
     type: object
-    additionalProperties: false
     properties:
       clone_url:
         description: The HTTP URL of the configuration content's git repository.
@@ -105,7 +98,6 @@ definitions:
         - version
       description: A component with a name and version.
       type: object
-      additionalProperties: false
       properties:
         name:
           type: string
@@ -123,7 +115,6 @@ definitions:
   HostedRepository:
     description: A hosted-type package repository.
     type: object
-    additionalProperties: false
     required:
       - name
       - type
@@ -139,7 +130,6 @@ definitions:
   GroupRepository:
     description: A group-type package repository.
     type: object
-    additionalProperties: false
     required:
       - name
       - members

--- a/cray_product_catalog/util.py
+++ b/cray_product_catalog/util.py
@@ -1,0 +1,34 @@
+"""
+Defines utility functions used by other modules.
+
+MIT License
+
+(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+"""
+from kubernetes import config
+
+
+def load_k8s():
+    """ Load Kubernetes Configuration """
+    try:
+        config.load_incluster_config()
+    except Exception:
+        config.load_kube_config()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 jsonschema
 kubernetes
 pyyaml
+urllib3

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,0 +1,137 @@
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Mock data for ProductCatalog and InstalledProductVersion unit tests
+
+from yaml import safe_dump
+
+
+# Two versions of a product named SAT where:
+# - The two versions have have no docker images in common with one another.
+# - Both have configurations, but neither have images or recipes
+SAT_VERSIONS = {
+    '2.0.0': {
+        'component_versions': {
+            'docker': [
+                {'name': 'cray/cray-sat', 'version': '1.0.0'},
+                {'name': 'cray/sat-cfs-install', 'version': '1.4.0'}
+            ],
+            'repositories': [
+                {'name': 'sat-sle-15sp2', 'type': 'group', 'members': ['sat-2.0.0-sle-15sp2']},
+                {'name': 'sat-2.0.0-sle-15sp2', 'type': 'hosted'}
+            ]
+        },
+        "configuration": {
+           "clone_url": "https://vcs.machine.dev.cray.com/vcs/cray/sat-config-management.git",
+           "commit": "5b7e74714c7f789e474ac9dbc2cae5c04d0e8e33",
+           "import_branch": "cray/sat/2.0.0",
+           "import_date": "2021-07-07T22:13:32.462655Z",
+           "ssh_url": "git@vcs.machine.dev.cray.com:cray/sat-config-management.git"
+        }
+    },
+    '2.0.1': {
+        'component_versions': {
+            'docker': [
+                {'name': 'cray/cray-sat', 'version': '1.0.1'},
+                {'name': 'cray/sat-other-image', 'version': '1.4.0'}
+            ],
+            'repositories': [
+                {'name': 'sat-sle-15sp2', 'type': 'group', 'members': ['sat-2.0.1-sle-15sp2']},
+                {'name': 'sat-2.0.1-sle-15sp2', 'type': 'hosted'}
+            ]
+        },
+        "configuration": {
+            "clone_url": "https://vcs.machine.dev.cray.com/vcs/cray/sat-config-management.git",
+            "commit": "e1fa10b6865fb47ced6c1a6cfab2bc28fe149a74",
+            "import_branch": "cray/sat/2.0.1",
+            "import_date": "2021-10-26T15:23:06.078295Z",
+            "ssh_url": "git@vcs.machine.dev.cray.com:cray/sat-config-management.git"
+        }
+    },
+}
+
+# Two versions of a product named COS where:
+# - The two versions have one docker image name and version in common
+# - The first version has no repositories, configuration, images, or recipes
+# - The second version has repositories, configuration, images, and recipes
+COS_VERSIONS = {
+    '2.0.0': {
+        'component_versions': {
+            'docker': [
+                {'name': 'cray/cray-cos', 'version': '1.0.0'},
+                {'name': 'cray/cos-cfs-install', 'version': '1.4.0'}
+            ]
+        }
+    },
+    '2.0.1': {
+        'component_versions': {
+            'docker': [
+                {'name': 'cray/cray-cos', 'version': '1.0.1'},
+                {'name': 'cray/cos-cfs-install', 'version': '1.4.0'}
+            ],
+            'repositories': [
+                {'name': 'cos-sle-15sp2', 'type': 'group', 'members': ['cos-2.0.1-sle-15sp2']},
+                {'name': 'cos-2.0.1-sle-15sp2', 'type': 'hosted'}
+            ]
+        },
+        "configuration": {
+            "clone_url": "https://vcs.machine.dev.cray.com/vcs/cray/cos-config-management.git",
+            "commit": "f0b17e13fcf7dd3b896196776e4547fdb98f1da7",
+            "import_branch": "cray/cos/2.0.1",
+            "import_date": "2021-11-24T12:04:25.210495Z",
+            "ssh_url": "git@vcs.machine.dev.cray.com:cray/cos-config-management.git"
+        },
+        "images": {
+            "cray-shasta-compute-sles15sp2.x86_64-1.5.66": {
+                "id": "e2d58d7e-42b7-434d-b689-31ca3d053c51"
+            }
+        },
+        "recipes": {
+            "cray-shasta-compute-sles15sp2.x86_64-1.5.66": {
+                "id": "54bc9447-73ba-4b06-a647-e5225451596d"
+            }
+        }
+    },
+}
+
+# One version of "Other Product" that also uses cray/cray-sat:1.0.1
+OTHER_PRODUCT_VERSION = {
+    '2.0.0': {
+        'component_versions': {
+            'docker': [
+                {'name': 'cray/cray-sat', 'version': '1.0.1'},
+            ],
+            'repositories': [
+                {'name': 'sat-sle-15sp2', 'type': 'group', 'members': ['sat-2.0.0-sle-15sp2']},
+                {'name': 'sat-2.0.0-sle-15sp2', 'type': 'hosted'}
+            ]
+        }
+    }
+}
+
+
+# A mock version of the data returned when querying the Product Catalog ConfigMap
+MOCK_PRODUCT_CATALOG_DATA = {
+    'sat': safe_dump(SAT_VERSIONS),
+    'cos': safe_dump(COS_VERSIONS),
+    'other_product': safe_dump(OTHER_PRODUCT_VERSION)
+}

--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -113,15 +113,14 @@ class TestSchemaValidation(unittest.TestCase):
         validate(CONFIG_ONLY_FORMAT)
 
     def test_with_images_and_recipes(self):
-        """Test when """
+        """Test when images and recipes are present."""
         validate(IMAGES_AND_RECIPES)
 
     def test_extra_top_level_key(self):
-        """Test adding an extra top level key does not validate."""
+        """Test adding an extra top level key still validates."""
         data_to_validate = copy.deepcopy(SAT_NEW_FORMAT)
         data_to_validate['foo'] = 'bar'
-        with self.assertRaises(ValidationError):
-            validate(data_to_validate)
+        validate(data_to_validate)
 
     @unittest.skip('There is no way to assert a UUID format yet.')
     def test_non_uuid(self):
@@ -134,18 +133,16 @@ class TestSchemaValidation(unittest.TestCase):
             validate(data_to_validate)
 
     def test_extra_component_key(self):
-        """Test adding unrecognized component versions does not validate."""
+        """Test adding additional properties to component_versions still validates."""
         data_to_validate = copy.deepcopy(SAT_NEW_FORMAT)
         data_to_validate['component_versions']['apk'] = [{'name': 'foo', 'version': 'bar'}]
-        with self.assertRaises(ValidationError):
-            validate(data_to_validate)
+        validate(data_to_validate)
 
     def test_extra_component_version_key(self):
-        """Test adding unrecognized component version attributes does not validate."""
+        """Test adding unrecognized component version properties still validates."""
         data_to_validate = copy.deepcopy(SAT_NEW_FORMAT)
         data_to_validate['component_versions']['rpm'][0]['lastUpdated'] = 'yesterday'
-        with self.assertRaises(ValidationError):
-            validate(data_to_validate)
+        validate(data_to_validate)
 
     def test_missing_component_version_key(self):
         """Test a component missing a required key does not validate."""
@@ -155,11 +152,10 @@ class TestSchemaValidation(unittest.TestCase):
             validate(data_to_validate)
 
     def test_with_extra_repository_key(self):
-        """Test a component with invalid repository data does not validate."""
+        """Test a component with additional property in a repository still validates."""
         data_to_validate = copy.deepcopy(SAT_NEW_FORMAT)
         data_to_validate['component_versions']['repositories'][0]['another_field'] = 'other_stuff'
-        with self.assertRaises(ValidationError):
-            validate(data_to_validate)
+        validate(data_to_validate)
 
     def test_invalid_repo_key(self):
         """Test a component with invalid repository type does not validate."""
@@ -172,13 +168,6 @@ class TestSchemaValidation(unittest.TestCase):
         """Test a group type repo that does not have a 'members' key does not validate."""
         data_to_validate = copy.deepcopy(SAT_NEW_FORMAT)
         del data_to_validate['component_versions']['repositories'][0]['members']
-        with self.assertRaises(ValidationError):
-            validate(data_to_validate)
-
-    def test_hosted_repo_with_members_key(self):
-        """Test a hosted type repo that does have a 'members' key does not validate."""
-        data_to_validate = copy.deepcopy(SAT_NEW_FORMAT)
-        data_to_validate['component_versions']['repositories'][1]['members'] = ['sat-2.1.12-sle-15sp2']
         with self.assertRaises(ValidationError):
             validate(data_to_validate)
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -112,7 +112,7 @@ class TestProductCatalog(unittest.TestCase):
     def test_create_product_catalog_invalid_product_schema(self):
         """Test creating a ProductCatalog when an entry contains valid YAML but does not match schema."""
         self.mock_k8s_api.read_namespaced_config_map.return_value = Mock(data={
-            'sat': safe_dump({'2.1': {'this_key_is_not_allowed': {}}})
+            'sat': safe_dump({'2.1': {'component_versions': {'docker': 'should be an array'}}})
         })
         with self.assertLogs(level=logging.DEBUG) as logs_cm:
             product_catalog = self.create_and_assert_product_catalog()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,330 @@
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Unit tests for cray_product_catalog.query module
+
+import copy
+import logging
+import unittest
+from unittest.mock import Mock, patch
+
+from kubernetes.config import ConfigException
+from yaml import safe_dump
+
+from cray_product_catalog.query import (
+    ProductCatalog,
+    InstalledProductVersion,
+    ProductCatalogError
+)
+from tests.mocks import COS_VERSIONS, MOCK_PRODUCT_CATALOG_DATA, SAT_VERSIONS
+
+
+class TestGetK8sAPI(unittest.TestCase):
+    """Tests for ProductCatalog.get_k8s_api()."""
+
+    def setUp(self):
+        """Set up mocks."""
+        self.mock_load_k8s = patch('cray_product_catalog.query.load_k8s').start()
+        self.mock_corev1api = patch('cray_product_catalog.query.CoreV1Api').start()
+
+    def tearDown(self):
+        """Stop patches."""
+        patch.stopall()
+
+    def test_get_k8s_api(self):
+        """Test the successful case of get_k8s_api."""
+        api = ProductCatalog._get_k8s_api()
+        self.mock_load_k8s.assert_called_once_with()
+        self.mock_corev1api.assert_called_once_with()
+        self.assertEqual(api, self.mock_corev1api.return_value)
+
+    def test_get_k8s_api_config_exception(self):
+        """Test when configuration can't be loaded."""
+        self.mock_load_k8s.side_effect = ConfigException
+        with self.assertRaises(ProductCatalogError):
+            ProductCatalog._get_k8s_api()
+        self.mock_load_k8s.assert_called_once_with()
+        self.mock_corev1api.assert_not_called()
+
+
+class TestProductCatalog(unittest.TestCase):
+    """Tests for the ProductCatalog class."""
+
+    def setUp(self):
+        """Set up mocks."""
+        self.mock_k8s_api = patch.object(ProductCatalog, '_get_k8s_api').start().return_value
+        self.mock_product_catalog_data = copy.deepcopy(MOCK_PRODUCT_CATALOG_DATA)
+        self.mock_k8s_api.read_namespaced_config_map.return_value = Mock(data=self.mock_product_catalog_data)
+
+    def tearDown(self):
+        """Stop patches."""
+        patch.stopall()
+
+    def create_and_assert_product_catalog(self):
+        """Assert the product catalog was created as expected."""
+        product_catalog = ProductCatalog('mock-name', 'mock-namespace')
+        self.mock_k8s_api.read_namespaced_config_map.assert_called_once_with('mock-name', 'mock-namespace')
+        return product_catalog
+
+    def test_create_product_catalog(self):
+        """Test creating a simple ProductCatalog."""
+        product_catalog = self.create_and_assert_product_catalog()
+        expected_names_and_versions = [
+            (name, version) for name in ('sat', 'cos') for version in ('2.0.0', '2.0.1')
+        ] + [('other_product', '2.0.0')]
+        actual_names_and_versions = [
+            (product.name, product.version) for product in product_catalog.products
+        ]
+        self.assertEqual(expected_names_and_versions, actual_names_and_versions)
+
+    def test_create_product_catalog_invalid_product_data(self):
+        """Test creating a ProductCatalog when the product catalog contains invalid YAML."""
+        self.mock_product_catalog_data['sat'] = '\t'
+        with self.assertRaisesRegex(ProductCatalogError, 'Failed to load ConfigMap data'):
+            self.create_and_assert_product_catalog()
+
+    def test_create_product_catalog_null_data(self):
+        """Test creating a ProductCatalog when the product catalog contains null data."""
+        self.mock_k8s_api.read_namespaced_config_map.return_value = Mock(data=None)
+        with self.assertRaisesRegex(ProductCatalogError,
+                                    'No data found in mock-namespace/mock-name ConfigMap.'):
+            self.create_and_assert_product_catalog()
+
+    def test_create_product_catalog_invalid_product_schema(self):
+        """Test creating a ProductCatalog when an entry contains valid YAML but does not match schema."""
+        self.mock_k8s_api.read_namespaced_config_map.return_value = Mock(data={
+            'sat': safe_dump({'2.1': {'this_key_is_not_allowed': {}}})
+        })
+        with self.assertLogs(level=logging.DEBUG) as logs_cm:
+            product_catalog = self.create_and_assert_product_catalog()
+
+        self.assertEqual(1, len(logs_cm.records))
+        self.assertEqual('The following products have product catalog data that '
+                         'is not valid against the expected schema: sat-2.1',
+                         logs_cm.records[0].message)
+        self.assertEqual(product_catalog.products, [])
+
+    def test_get_matching_product(self):
+        """Test getting a particular product by name/version."""
+        product_catalog = self.create_and_assert_product_catalog()
+        expected_matching_name_and_version = ('cos', '2.0.0')
+        actual_matching_product = product_catalog.get_product('cos', '2.0.0')
+        self.assertEqual(
+            expected_matching_name_and_version, (actual_matching_product.name, actual_matching_product.version)
+        )
+        expected_component_data = COS_VERSIONS['2.0.0']
+        self.assertEqual(expected_component_data, actual_matching_product.data)
+
+    def test_get_latest_matching_product(self):
+        """Test getting the latest version of a product"""
+        product_catalog = self.create_and_assert_product_catalog()
+        expected_matching_name_and_version = ('sat', '2.0.1')
+        actual_matching_product = product_catalog.get_product('sat')
+        self.assertEqual(expected_matching_name_and_version,
+                         (actual_matching_product.name, actual_matching_product.version))
+        expected_component_data = SAT_VERSIONS['2.0.1']
+        self.assertEqual(expected_component_data, actual_matching_product.data)
+
+
+class TestInstalledProductVersion(unittest.TestCase):
+    """Tests for the InstalledProductVersion class."""
+    def setUp(self):
+        """Create an InstalledProductVersion object to test"""
+        # Use this product version because its data is most complete
+        self.installed_product_version = InstalledProductVersion(
+            'cos', '2.0.1', COS_VERSIONS['2.0.1']
+        )
+
+    def tearDown(self):
+        """Stop patches."""
+        patch.stopall()
+
+    def test_docker_images(self):
+        """Test getting the Docker images."""
+        expected_docker_image_versions = [('cray/cray-cos', '1.0.1'),
+                                          ('cray/cos-cfs-install', '1.4.0')]
+        self.assertEqual(
+            expected_docker_image_versions, self.installed_product_version.docker_images
+        )
+
+    def test_no_docker_images(self):
+        """Test a product that has an empty dictionary under the 'docker' key returns an empty dictionary."""
+        product_with_no_docker_images = InstalledProductVersion(
+            'sat', '0.9.9', {'component_versions': {'docker': {}}}
+        )
+        self.assertEqual(product_with_no_docker_images.docker_images, [])
+
+    def test_no_docker_images_null(self):
+        """Test a product that has None under the 'docker' key returns an empty dictionary."""
+        product_with_no_docker_images = InstalledProductVersion(
+            'sat', '0.9.9', {'component_versions': {'docker': None}}
+        )
+        self.assertEqual(product_with_no_docker_images.docker_images, [])
+
+    def test_no_docker_images_empty_list(self):
+        """Test a product that has an empty list under the 'docker' key returns an empty dictionary."""
+        product_with_no_docker_images = InstalledProductVersion(
+            'sat', '0.9.9', {'component_versions': {'docker': []}}
+        )
+        self.assertEqual(product_with_no_docker_images.docker_images, [])
+
+    def test_str(self):
+        """Test the string representation of InstalledProductVersion."""
+        expected_str = 'cos-2.0.1'
+        self.assertEqual(
+            expected_str, str(self.installed_product_version)
+        )
+
+    def test_group_repos(self):
+        """Test getting group repo data for an InstalledProductVersion."""
+        expected_group_repos = [{'members': ['cos-2.0.1-sle-15sp2'], 'name': 'cos-sle-15sp2', 'type': 'group'}]
+        self.assertEqual(
+            expected_group_repos, self.installed_product_version.group_repositories
+        )
+
+    def test_hosted_repos(self):
+        """Test getting hosted repo names for an InstalledProductVersion."""
+        expected_hosted_repo_names = {'cos-2.0.1-sle-15sp2'}
+        self.assertEqual(
+            expected_hosted_repo_names, self.installed_product_version.hosted_and_member_repo_names
+        )
+
+    def test_hosted_repos_without_members(self):
+        """Test getting hosted repo names that are listed only as hosted repos but not a member of a group."""
+        sat_version_data = copy.deepcopy(SAT_VERSIONS['2.0.0'])
+        sat_version_data['component_versions']['repositories'] = [
+            {'name': 'my-hosted-repo', 'type': 'hosted'}
+        ]
+        ipv = InstalledProductVersion('sat', '2.0.0', sat_version_data)
+        expected_hosted_repo_names = {'my-hosted-repo'}
+        self.assertEqual(ipv.hosted_and_member_repo_names, expected_hosted_repo_names)
+
+    def test_hosted_repos_only_members(self):
+        """Test getting hosted repo names that are not listed except as a member of a group."""
+        sat_version_data = copy.deepcopy(SAT_VERSIONS['2.0.0'])
+        sat_version_data['component_versions']['repositories'] = [
+            {'name': 'my-group-repo', 'type': 'group', 'members': ['my-hosted-repo']}
+        ]
+        ipv = InstalledProductVersion('sat', '2.0.0', sat_version_data)
+        expected_hosted_repo_names = {'my-hosted-repo'}
+        self.assertEqual(ipv.hosted_and_member_repo_names, expected_hosted_repo_names)
+
+    def test_configuration_items_present(self):
+        """Test getting configuration values when the product includes them."""
+        attr_and_expected_val = [
+            ('clone_url', 'https://vcs.machine.dev.cray.com/vcs/cray/cos-config-management.git'),
+            ('commit', 'f0b17e13fcf7dd3b896196776e4547fdb98f1da7'),
+            ('import_branch', 'cray/cos/2.0.1')
+        ]
+        for attr, expected_val in attr_and_expected_val:
+            with self.subTest(attr=attr):
+                self.assertEqual(expected_val, getattr(self.installed_product_version, attr))
+
+    def test_configuration_items_missing(self):
+        """Test getting configuration values when the product does not include them in its configuration data."""
+        attrs = ['clone_url', 'commit', 'import_branch']
+        for attr in attrs:
+            with self.subTest(attr=attr):
+                cos_version_data = copy.deepcopy(COS_VERSIONS['2.0.1'])
+                del cos_version_data['configuration'][attr]
+                ipv = InstalledProductVersion('cos', '2.0.1', cos_version_data)
+                self.assertIsNone(getattr(ipv, attr))
+
+    def test_configuration_missing(self):
+        """Test getting configuration values when the product does not include any configuration data."""
+        attrs = ['clone_url', 'commit', 'import_branch']
+        cos_version_data = copy.deepcopy(COS_VERSIONS['2.0.1'])
+        del cos_version_data['configuration']
+        ipv = InstalledProductVersion('cos', '2.0.1', cos_version_data)
+        for attr in attrs:
+            with self.subTest(attr=attr):
+                self.assertIsNone(getattr(ipv, attr))
+
+    def test_recipes(self):
+        """Test getting recipes when the product has one."""
+        expected_recipes = [{'name': 'cray-shasta-compute-sles15sp2.x86_64-1.5.66',
+                             'id': '54bc9447-73ba-4b06-a647-e5225451596d'}]
+        self.assertEqual(expected_recipes, self.installed_product_version.recipes)
+
+    def test_images(self):
+        """Test getting images when the product has one."""
+        expected_images = [{'name': 'cray-shasta-compute-sles15sp2.x86_64-1.5.66',
+                            'id': 'e2d58d7e-42b7-434d-b689-31ca3d053c51'}]
+        self.assertEqual(expected_images, self.installed_product_version.images)
+
+    def test_ims_resources_missing(self):
+        """Test getting recipes/images when the product has no corresponding key in its data."""
+        ipv = InstalledProductVersion('sat', '2.0.0', SAT_VERSIONS['2.0.0'])
+        for attr in ['recipes', 'images']:
+            with self.subTest(attr=attr):
+                self.assertEqual([], getattr(ipv, attr))
+
+    def test_ims_resources_null(self):
+        """Test getting recipes/images when the product has a null value for the corresponding key."""
+        for attr in ['recipes', 'images']:
+            sat_version_data = copy.deepcopy(SAT_VERSIONS['2.0.0'])
+            sat_version_data[attr] = None
+            ipv = InstalledProductVersion('sat', '2.0.0', sat_version_data)
+            with self.subTest(attr=attr):
+                self.assertEqual([], getattr(ipv, attr))
+
+    def test_ims_resources_empty(self):
+        """Test getting recipes/images when the product has an empty dict value for the corresponding key."""
+        for attr in ['recipes', 'images']:
+            sat_version_data = copy.deepcopy(SAT_VERSIONS['2.0.0'])
+            sat_version_data[attr] = {}
+            ipv = InstalledProductVersion('sat', '2.0.0', sat_version_data)
+            with self.subTest(attr=attr):
+                self.assertEqual([], getattr(ipv, attr))
+
+    def test_active_true(self):
+        """Test active when 'active' key is present and True"""
+        cos_version_data = copy.deepcopy(COS_VERSIONS['2.0.1'])
+        cos_version_data['active'] = True
+        ipv = InstalledProductVersion('cos', '2.0.1', cos_version_data)
+        self.assertTrue(ipv.active)
+
+    def test_active_false(self):
+        """Test active when 'active' key is present and True"""
+        cos_version_data = copy.deepcopy(COS_VERSIONS['2.0.1'])
+        cos_version_data['active'] = False
+        ipv = InstalledProductVersion('cos', '2.0.1', cos_version_data)
+        self.assertFalse(ipv.active)
+
+    def test_active_key_missing(self):
+        """Test active when 'active' key is present and True"""
+        self.assertFalse(self.installed_product_version.active)
+
+    def test_active_supported_key_missing(self):
+        """Test active_supported when 'active' key is missing"""
+        self.assertFalse(self.installed_product_version.supports_active)
+
+    def test_active_supported_key_present(self):
+        """Test active_supported when 'active' key is present"""
+        cos_version_data = copy.deepcopy(COS_VERSIONS['2.0.1'])
+        cos_version_data['active'] = True
+        ipv = InstalledProductVersion('cos', '2.0.1', cos_version_data)
+        self.assertTrue(ipv.supports_active)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary and Scope

This adds a new module, `query.py`, which clients can use to query the `cray-product-catalog` Kubernetes ConfigMap to get information about the products installed on the system.

This new module is not exposed as an executable script in the Docker image like `catalog_update` and `catalog_delete`. Rather, it is meant to be used as a library in other Python projects.

This repository is a logical place for such a library because the query code must validate the product catalog data against the schema before processing, and this repository already contains the schema definition and validation code.

The `catalog_update` and `catalog_delete` scripts are mostly unaffected. One minor change was made to define the `load_k8s` function in a common `util` module since it is now used in 3 places.

This change is backwards compatible. Existing users of the `catalog_update` and `catalog_delete` scripts are not affected.

The schema for product catalog data is also relaxed slightly. Validation against the schema is already opt-in behavior only used by a couple products (SAT and COS).

## Issues and Related PRs

* Resolves [CRAYSAT-1314](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1314)

## Testing

### Tested on:

* Unit tests have been run in a local Python virtualenv on my macbook.
* Other testing described below occurred on baldar.

### Test description:
New unit tests have been added and all are passing.

Installed into a Python virtualenv on baldar and ran a script which used the `ProductCatalog` class to print information about installed versions of products.

Used this code as a dependency in the `sat` python package and tested `sat bootprep` and `sat showrev` commands that use it.

The following two tests have been deferred because this was not working in existing released version 1.5.5 (see [CASMCMS-8002)](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8002):

- [x] Modified a loftsman manifest that deploys `sat-cfs-install` to use this version of the cray-product-catalog-update container image. Deployed the manifest and ensured that the `cray-product-catalog` K8s ConfigMap was updated.
- [x] Ran the container under `podman` to update the `cray-product-catalog` K8s ConfigMap as is done in certain product installers, including SAT.

## Risks and Mitigations

Risk should be minimal as this mostly adds new code that can be used by other Python projects.

## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Is a new version being released? Update https://github.com/Cray-HPE/cray-product-catalog/wiki/CSM-Compatibility-Matrix
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
