### PR TITLE
CASM-3555, CASM-3556: Handle concurrent and finer-grained updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reverted github workflows regarding image building and publishing and 
   releases back to Jenkins pipelines.
 
+### Added
+
+- Improved concurrency handling by checking for resource conflicts when updating
+  the config map.
+- Improved the ability to update more specific portions of the config map by adding
+  a recursive `merge_dict` utility that is used to merge input data into the existing
+  config map.
+
 ## [1.6.0] - 2022-05-09
 
 ### Added

--- a/cray_product_catalog/catalog_delete.py
+++ b/cray_product_catalog/catalog_delete.py
@@ -48,7 +48,6 @@ from urllib3.util.retry import Retry
 
 from kubernetes import client
 from kubernetes.client.api_client import ApiClient
-from kubernetes.client.configuration import Configuration
 from kubernetes.client.rest import ApiException
 import yaml
 
@@ -76,7 +75,7 @@ def modify_config_map(name, namespace, product, product_version, key=None):
     3. Read back the config_map
     4. Repeat steps 2-3 if config_map does not reflect the changes requested
     """
-    k8sclient = ApiClient(configuration=Configuration())
+    k8sclient = ApiClient()
     retries = 100
     retry = Retry(
         total=retries, read=retries, connect=retries, backoff_factor=0.3,

--- a/cray_product_catalog/catalog_update.py
+++ b/cray_product_catalog/catalog_update.py
@@ -43,11 +43,14 @@ from jsonschema.exceptions import ValidationError
 from kubernetes import client
 from kubernetes.client.api_client import ApiClient
 from kubernetes.client.configuration import Configuration
+from kubernetes.client.models.v1_config_map import V1ConfigMap
+from kubernetes.client.models.v1_object_meta import V1ObjectMeta
 from kubernetes.client.rest import ApiException
 import yaml
 
 from cray_product_catalog.schema.validate import validate
-from cray_product_catalog.util import load_k8s
+from cray_product_catalog.util.k8s import load_k8s
+from cray_product_catalog.util.merge_dict import merge_dict
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -66,6 +69,9 @@ CONFIG_MAP_NAMESPACE = os.environ.get("CONFIG_MAP_NAMESPACE", "services").strip(
 YAML_CONTENT = os.environ.get("YAML_CONTENT").strip()  # required
 SET_ACTIVE_VERSION = bool(os.environ.get("SET_ACTIVE_VERSION"))
 VALIDATE_SCHEMA = bool(os.environ.get("VALIDATE_SCHEMA"))
+
+ERR_NOT_FOUND = 404
+ERR_CONFLICT = 409
 
 
 def validate_schema(data):
@@ -111,9 +117,11 @@ def update_config_map(data, name, namespace):
     Get the config map `data` to be added.
 
     1. Wait for the config map to be present in the namespace
-    2. Patch the config_map
-    3. Read back the config_map
-    4. Repeat steps 2-3 if config_map does not include the changes requested
+    2. Read the config map
+    3. Patch the config_map
+    4. Read back the config_map
+    5. Repeat steps 2-4 if config_map does not include the changes requested,
+       or if step 3 failed due to a conflict.
     """
     k8sclient = ApiClient(configuration=Configuration())
     retries = 100
@@ -142,7 +150,7 @@ def update_config_map(data, name, namespace):
             LOGGER.exception("Error calling read_namespaced_config_map")
 
             # Config map doesn't exist yet
-            if e.status == 404:
+            if e.status == ERR_NOT_FOUND:
                 LOGGER.warning("ConfigMap %s/%s doesn't exist, attempting again.", namespace, name)
                 continue
             else:
@@ -163,13 +171,13 @@ def update_config_map(data, name, namespace):
                 product_data[PRODUCT_VERSION] = {}
             # Key with same version exists in ConfigMap
             else:
-                if (data.items() <= product_data[PRODUCT_VERSION].items()
+                if (merge_dict(data, product_data[PRODUCT_VERSION]) == product_data[PRODUCT_VERSION]
                         and (current_version_is_active(product_data) or not SET_ACTIVE_VERSION)):
                     LOGGER.info("ConfigMap data updates exist; Exiting.")
                     break
 
         # Patch the config map if needed
-        product_data[PRODUCT_VERSION].update(data)
+        product_data[PRODUCT_VERSION] = merge_dict(data, product_data[PRODUCT_VERSION])
         if SET_ACTIVE_VERSION:
             set_active_version(product_data)
         config_map_data[PRODUCT] = yaml.safe_dump(
@@ -177,11 +185,21 @@ def update_config_map(data, name, namespace):
         )
         LOGGER.info("ConfigMap update attempt=%s", attempt)
         try:
-            api_instance.patch_namespaced_config_map(
-                name, namespace, client.V1ConfigMap(data=config_map_data)
+            new_config_map = V1ConfigMap(data=config_map_data)
+            new_config_map.metadata = V1ObjectMeta(
+                name=name, resource_version=response.metadata.resource_version
             )
-        except ApiException:
-            LOGGER.exception("Error calling patch_namespaced_config_map")
+            api_instance.patch_namespaced_config_map(
+                name, namespace, body=new_config_map
+            )
+        except ApiException as e:
+            if e.status == ERR_CONFLICT:
+                # A conflict is raised if the resourceVersion field was unexpectedly
+                # incremented, e.g. if another process updated the config map. This
+                # provides concurrency protection.
+                LOGGER.warning("Conflict updating config map")
+            else:
+                LOGGER.exception("Error calling replace_namespaced_config_map")
 
 
 def main():

--- a/cray_product_catalog/catalog_update.py
+++ b/cray_product_catalog/catalog_update.py
@@ -42,7 +42,6 @@ from urllib3.util.retry import Retry
 from jsonschema.exceptions import ValidationError
 from kubernetes import client
 from kubernetes.client.api_client import ApiClient
-from kubernetes.client.configuration import Configuration
 from kubernetes.client.models.v1_config_map import V1ConfigMap
 from kubernetes.client.models.v1_object_meta import V1ObjectMeta
 from kubernetes.client.rest import ApiException
@@ -123,7 +122,7 @@ def update_config_map(data, name, namespace):
     5. Repeat steps 2-4 if config_map does not include the changes requested,
        or if step 3 failed due to a conflict.
     """
-    k8sclient = ApiClient(configuration=Configuration())
+    k8sclient = ApiClient()
     retries = 100
     retry = Retry(
         total=retries, read=retries, connect=retries, backoff_factor=0.3,

--- a/cray_product_catalog/util/__init__.py
+++ b/cray_product_catalog/util/__init__.py
@@ -20,14 +20,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# Defines utility functions used by other modules.
+# Defines a utility function for loading the k8s config.
 
-from kubernetes import config
-
-
-def load_k8s():
-    """ Load Kubernetes Configuration """
-    try:
-        config.load_incluster_config()
-    except Exception:
-        config.load_kube_config()
+# import load_k8s here so that load_k8s can be imported from cray_product_catalog.util
+from cray_product_catalog.util.k8s import load_k8s

--- a/cray_product_catalog/util/k8s.py
+++ b/cray_product_catalog/util/k8s.py
@@ -1,0 +1,33 @@
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Defines a utility function for loading the k8s config.
+
+from kubernetes import config
+
+
+def load_k8s():
+    """ Load Kubernetes Configuration """
+    try:
+        config.load_incluster_config()
+    except Exception:
+        config.load_kube_config()

--- a/cray_product_catalog/util/merge_dict.py
+++ b/cray_product_catalog/util/merge_dict.py
@@ -1,0 +1,156 @@
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Contains a utility function for merging two dictionaries together.
+
+from copy import deepcopy
+
+
+def _dict_contains_no_subdicts_or_lists(dict_to_check):
+    """Return true if the given dict has no list or dictionary values.
+
+    Helper for merge_dict.
+
+    Args:
+        dict_to_check (dict): The dict to check for list/dictionary values.
+
+    Returns:
+        bool: True if the dict has no dict or list values.
+    """
+    return not any(isinstance(value, dict) or isinstance(value, list)
+                   for value in dict_to_check.values())
+
+
+def _values_are_dicts(*values):
+    """Return true if all given values are dict type.
+
+    Helper for merge_dict.
+
+    Args:
+        *values: A list of values to check.
+
+    Returns:
+        bool: True if the values are dicts.
+    """
+    return all(isinstance(v, dict) for v in values)
+
+
+def _values_are_lists(*values):
+    """Return true if all values are list type.
+
+    Helper for merge_dict.
+
+    Args:
+        *values: A list of values to check.
+
+    Returns:
+        bool: True if the values are lists.
+    """
+    return all(isinstance(v, list) for v in values)
+
+
+def _values_are_different_types(first_value, second_value):
+    """Return true if two values are not the same type.
+
+    Helper for merge_dict.
+
+    Args:
+        first_value: the value to compare with second_value.
+        second_value: the value to compare with first_value.
+
+    Returns:
+        bool: True if the two values are not the same type.
+    """
+    return not (
+        isinstance(first_value, type(second_value)) and
+        isinstance(second_value, type(first_value))
+    )
+
+
+def _merge_input_with_existing(input_key, input_value, dict_to_update):
+    """Merge the given input with an existing dictionary.
+
+    Helper for merge_dict.
+
+    Args:
+        input_key: The key under which to insert the new data.
+        input_value: The new value to insert.
+        dict_to_update: The dictionary in which to insert the new data.
+
+    Returns:
+        None. Modifies dict_to_update in place.
+
+    Raises:
+        TypeError: if two values contain conflicting types that can't
+            be merged (e.g. merging a string with a list).
+    """
+    # If adding a new key not in the existing dict, just add it.
+    if input_key not in dict_to_update:
+        dict_to_update[input_key] = input_value
+    else:
+        if _values_are_dicts(dict_to_update[input_key], input_value):
+            # Merging two dicts, use merge_dict() recursively.
+            dict_to_update[input_key] = merge_dict(input_value, dict_to_update[input_key])
+        elif _values_are_lists(dict_to_update[input_key], input_value):
+            # Merging two lists, use extend().
+            dict_to_update[input_key].extend(input_value)
+        else:
+            if _values_are_different_types(input_value, dict_to_update[input_key]):
+                raise TypeError(
+                    f'Cannot merge {input_value} (type {type(input_value)}) '
+                    f'with {dict_to_update[input_key]} (type {type(dict_to_update[input_key])})'
+                )
+            # Data can't be merged, but should replace old with new.
+            dict_to_update[input_key] = input_value
+
+
+def merge_dict(input_dict, existing_dict):
+    """Merge two dictionaries and return the result.
+
+    Args:
+        input_dict: The dictionary to merge in.
+        existing_dict: The dictionary to which the input_dict data should be
+            added.
+
+    Returns:
+        dict: The updated dict.
+
+    Raises:
+        TypeError: if given arguments are not dict type.
+    """
+    if not _values_are_dicts(input_dict, existing_dict):
+        raise TypeError('Inputs to merge_dict must be dictionary type.')
+
+    # Avoid updating existing_dict in place
+    dict_to_return = deepcopy(existing_dict)
+
+    if _dict_contains_no_subdicts_or_lists(dict_to_return):
+        # Base case: can just use update().
+        dict_to_return.update(input_dict)
+        return dict_to_return
+
+    else:
+        # Recursive case: iterate over keys/values to add and update existing_dict.
+        for input_key, input_value in input_dict.items():
+            _merge_input_with_existing(input_key, input_value, dict_to_return)
+
+        return dict_to_return

--- a/tests/util/mocks.py
+++ b/tests/util/mocks.py
@@ -1,0 +1,120 @@
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Mock data for the cray_product_catalog.util module.
+
+# Trivial mock data: two dictionaries that can be merged just by
+# using the update() method, and the expected result.
+TRIVIAL_INPUT_DICT = {'apple': 'red'}
+
+TRIVIAL_EXISTING_DICT = {'pear': 'yellow'}
+
+TRIVIAL_EXPECTED_MERGE = {
+    'apple': 'red',
+    'pear': 'yellow'
+}
+
+# Product catalog mock data: two dictionaries that look like
+# what appears in the product catalog, and the expected results.
+PRODUCT_CATALOG_INPUT_DATA = {
+    'component_versions': {
+        'docker': [
+            {
+                'name': 'cray-pear',
+                'version': '2.0.0'
+            }
+        ]
+    }
+}
+
+PRODUCT_CATALOG_EXISTING_DATA = {
+    'component_versions': {
+        'docker': [
+            {
+                'name': 'cray-apple',
+                'version': '1.0.0'
+            }
+        ]
+    }
+}
+
+PRODUCT_CATALOG_EXPECTED_MERGE = {
+    'component_versions': {
+        'docker': [
+            {
+                'name': 'cray-apple',
+                'version': '1.0.0'
+            },
+            {
+                'name': 'cray-pear',
+                'version': '2.0.0'
+            }
+        ]
+    }
+}
+
+# "Complicated" mock data: two dictionaries that contain extra levels
+# of nesting and other data types to test a more complicated case for
+# merge_dict.
+COMPLICATED_INPUT_DICT = {
+    'recipe': ['flour'],
+    'steps': {
+        'prep': ['dice'],
+        'simmer': ['soup'],
+        'bake': ['time'],
+        'cleanup': {
+            'sweep': {'broom': 'floor'},
+            'dishes': {'towel': 'plates'}
+        }
+    },
+    'states': ['georgia'],
+    'age': 40,
+}
+
+COMPLICATED_EXISTING_DICT = {
+    'recipe': ['cinnamon', 'apples', 'sugar'],
+    'steps': {
+        'prep': ['chop', 'slice'],
+        'bake': ['preheat'],
+        'cleanup': {
+            'dishes': {'soap': 'plates', 'water': 'sink'}
+        }
+    },
+    'states': ['minnesota', 'texas'],
+    'age': 30,
+}
+
+
+COMPLICATED_EXPECTED_MERGE = {
+    'recipe': ['cinnamon', 'apples', 'sugar', 'flour'],
+    'steps': {
+        'prep': ['chop', 'slice', 'dice'],
+        'simmer': ['soup'],
+        'bake': ['preheat', 'time'],
+        'cleanup': {
+            'sweep': {'broom': 'floor'},
+            'dishes': {'soap': 'plates', 'water': 'sink', 'towel': 'plates'},
+        },
+    },
+    'states': ['minnesota', 'texas', 'georgia'],
+    'age': 40,
+}

--- a/tests/util/test_merge_dict.py
+++ b/tests/util/test_merge_dict.py
@@ -1,0 +1,82 @@
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Unit tests for the cray_product_catalog.util.merge_dict module
+
+from copy import deepcopy
+import unittest
+
+from cray_product_catalog.util.merge_dict import merge_dict
+
+from tests.util.mocks import (
+    COMPLICATED_INPUT_DICT,
+    COMPLICATED_EXISTING_DICT,
+    COMPLICATED_EXPECTED_MERGE,
+    PRODUCT_CATALOG_INPUT_DATA,
+    PRODUCT_CATALOG_EXISTING_DATA,
+    PRODUCT_CATALOG_EXPECTED_MERGE,
+    TRIVIAL_INPUT_DICT,
+    TRIVIAL_EXISTING_DICT,
+    TRIVIAL_EXPECTED_MERGE,
+)
+
+
+class TestMergeDict(unittest.TestCase):
+    """Tests for merge_dict."""
+
+    def test_trivial_merge_dict(self):
+        """Test a trivial case of merge_dict."""
+        expected = TRIVIAL_EXPECTED_MERGE
+        actual = merge_dict(TRIVIAL_INPUT_DICT, TRIVIAL_EXISTING_DICT)
+        self.assertEqual(expected, actual)
+
+    def test_simple_merge_dict(self):
+        """Test a simple case of merge_dict."""
+        expected = PRODUCT_CATALOG_EXPECTED_MERGE
+        actual = merge_dict(PRODUCT_CATALOG_INPUT_DATA, PRODUCT_CATALOG_EXISTING_DATA)
+        self.assertEqual(expected, actual)
+
+    def test_complicated_merge_dict(self):
+        """Test a more complicated example of merge_dict."""
+        expected = COMPLICATED_EXPECTED_MERGE
+        actual = merge_dict(COMPLICATED_INPUT_DICT, COMPLICATED_EXISTING_DICT)
+        self.assertEqual(expected, actual)
+
+    def test_merge_dict_unexpected_types(self):
+        """Test giving a non-dict to merge_dict."""
+        with self.assertRaises(TypeError):
+            merge_dict('bad_input_data', {})
+
+    def test_merge_dict_incompatible_types(self):
+        """Test merge_dict with two types that can't be merged."""
+        modified_input_data = deepcopy(COMPLICATED_INPUT_DICT)
+        modified_input_data['age'] = 'undefined'
+        with self.assertRaises(TypeError):
+            merge_dict(modified_input_data, COMPLICATED_EXISTING_DICT)
+
+    def test_inputs_unchanged(self):
+        """Test that merge_dict doesn't change the input values."""
+        input_dict = deepcopy(COMPLICATED_INPUT_DICT)
+        existing = deepcopy(COMPLICATED_EXISTING_DICT)
+        merge_dict(input_dict, existing)
+        self.assertEqual(input_dict, COMPLICATED_INPUT_DICT)
+        self.assertEqual(existing, COMPLICATED_EXISTING_DICT)


### PR DESCRIPTION
CASM-3555, CASM-3556: Handle concurrent and finer-grained updates

This commit adds a fix to provide better concurrency support when
updating the config map. When patching the config map, specify the
resource_version metadata field. This results in an HTTP 409 (conflict)
error if the target resource_version has unexpectedly changed (i.e.
some other process updated the config map first). This allows the process
to only update the config map when something else has not first updated it.

In order to provide finer-grained updates, introduce a utility function
called merge_dict which will recursively merge a dictionary so that individual
sub-components of the product catalog data can be updated without other
data being overwritten.

This commit also separates the util module into separate files, k8s.py
and merge_dict.py, to provide more separation between the merge_dict
function and its helpers and the load_k8s utility. To preserve the ability
to import load_k8s from cray_product_catalog.util,
cray_product_catalog.util.k8s.load_k8s is imported in the util package's
__init__ module.

Finally, this commit adds a change log entry.

Test Description:

I tested this in a local minikube environment in which I created the
services/cray-product-catalog config map manually.

Ran two cray-product-catalog-update processes (A and B), with a debug
break point in process A immediately prior to calling
replace_namespaced_config_map.

This resulted in process B updating the config map, without conflict,
between the time that process A read the config map and the time that
it attempted to replace it. As expected, this resulted in process A
receiving a conflict response and required it to re-read the config map
and update it once again. In the end, both process A and process B's
updates were reflected in the config map.

I tested inserting data into a large (i.e. nearly 1M) config map to
validate there were no issues with large config maps.

I also wrote unit tests for the merge_dict utility.

## Summary and Scope

See commit message

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASM-3555 and CASM-3556

## Testing

See commit message

## Pull Request Checklist

- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Is a new version being released? Update https://github.com/Cray-HPE/cray-product-catalog/wiki/CSM-Compatibility-Matrix
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable