### PR TITLE
CASM-3518: Add license check workflow

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -1,0 +1,43 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: Check Licenses
+
+on:
+  pull_request:
+
+jobs:
+  license-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v18.7
+
+    - name: License Check
+      if: ${{ steps.changed-files.outputs.all_changed_files }}
+      uses: docker://artifactory.algol60.net/csm-docker/stable/license-checker:latest
+      with:
+        args: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added a github workflow for checking license text separate from the organization-
+  wide "license-check" workflow.
 - Reverted github workflows regarding image building and publishing and 
   releases back to Jenkins pipelines.
 - Renamed `YAML_CONTENT` environment variable to `YAML_CONTENT_FILE`. For


### PR DESCRIPTION
This commit adds a workflow definition to run the license checker. This workflow is copied verbatim from the Cray-HPE/docs-csm repository.

## Summary and Scope

See commit message.

## Issues and Related PRs

* Required as part of CASM-3518

## Testing

### Test description:

Tested as a part of the pull request

## Risks and Mitigations

N/A

## Pull Request Checklist

- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Is a new version being released? Update https://github.com/Cray-HPE/cray-product-catalog/wiki/CSM-Compatibility-Matrix
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
