### PR TITLE
Log format, license check fix and add option to remove 'active' field.

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -29,15 +29,20 @@ on:
 jobs:
   license-check:
     runs-on: ubuntu-latest
+
+    container:
+      image: artifactory.algol60.net/csm-docker/stable/license-checker:latest
+      credentials:
+          username: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
+          password: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
+
     steps:
     - uses: actions/checkout@v3
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v18.7
+      uses: tj-actions/changed-files@v34
 
     - name: License Check
       if: ${{ steps.changed-files.outputs.all_changed_files }}
-      uses: docker://artifactory.algol60.net/csm-docker/stable/license-checker:latest
-      with:
-        args: ${{ steps.changed-files.outputs.all_changed_files }}
+      run: /usr/local/bin/python3 /license_check/license_check.py ${{ steps.changed-files.outputs.all_changed_files }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Modified github workflow for checking license text to use authenticated access to
+  artifactory server hosting license-checker image.
+
 ## [1.7.0] - 2022-11-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added an environment variable `REMOVE_ACTIVE_FIELD`. When set, the `catalog_update`
+  script will remove the 'active' field for all versions of the given product.
+
 ### Changed
 
 - Modified github workflow for checking license text to use authenticated access to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Modified github workflow for checking license text to use authenticated access to
   artifactory server hosting license-checker image.
+- Changed format of log messages to be prefixed with severity.
+
+### Fixed
+- Fixed an issue where log messages from child modules were not being printed.
 
 ## [1.7.0] - 2022-11-17
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ All configuration options are provided as environment variables.
 
  > The Kubernetes namespace of the `CONFIG_MAP`.
 
+ * `SET_ACTIVE_VERSION` = `''`
+
+ > When set, the given product-version will have a field called 'active' set to `true`. Other
+ > versions of the product will automatically have the field set to `false.` Cannot be used with
+ > `REMOVE_ACTIVE_FIELD` (see below).
+
+ * `REMOVE_ACTIVE_FIELD` = `''`
+
+ > When set, all versions of the given product will have the 'active' field removed from the
+ > ConfigMap data. Cannot be used with `SET_ACTIVE_VERSION` (see above).
+
 ## Versioning and Releases
 
 Versions are calculated automatically using `gitversion`. The full SemVer

--- a/cray_product_catalog/catalog_delete.py
+++ b/cray_product_catalog/catalog_delete.py
@@ -41,7 +41,6 @@
 import logging
 import os
 import random
-import sys
 import time
 import urllib3
 from urllib3.util.retry import Retry
@@ -51,16 +50,12 @@ from kubernetes.client.api_client import ApiClient
 from kubernetes.client.rest import ApiException
 import yaml
 
+from cray_product_catalog.logging import configure_logging
 from cray_product_catalog.util import load_k8s
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-# Logging
 LOGGER = logging.getLogger(__name__)
-LOGGER.setLevel(logging.INFO)
-handler = logging.StreamHandler(sys.stdout)
-handler.setLevel(logging.DEBUG)
-LOGGER.addHandler(handler)
 
 
 def modify_config_map(name, namespace, product, product_version, key=None):
@@ -163,6 +158,7 @@ def modify_config_map(name, namespace, product, product_version, key=None):
 
 
 def main():
+    configure_logging()
     # Parameters to identify config map and product/version to remove
     PRODUCT = os.environ.get("PRODUCT").strip()  # required
     PRODUCT_VERSION = os.environ.get("PRODUCT_VERSION").strip()  # required

--- a/cray_product_catalog/catalog_update.py
+++ b/cray_product_catalog/catalog_update.py
@@ -34,7 +34,6 @@
 import logging
 import os
 import random
-import sys
 import time
 import urllib3
 from urllib3.util.retry import Retry
@@ -47,18 +46,12 @@ from kubernetes.client.models.v1_object_meta import V1ObjectMeta
 from kubernetes.client.rest import ApiException
 import yaml
 
+from cray_product_catalog.logging import configure_logging
 from cray_product_catalog.schema.validate import validate
 from cray_product_catalog.util.k8s import load_k8s
 from cray_product_catalog.util.merge_dict import merge_dict
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-
-# Logging
-LOGGER = logging.getLogger(__name__)
-LOGGER.setLevel(logging.INFO)
-handler = logging.StreamHandler(sys.stdout)
-handler.setLevel(logging.DEBUG)
-LOGGER.addHandler(handler)
 
 # Parameters to identify config map and content in it to update
 PRODUCT = os.environ.get("PRODUCT").strip()  # required
@@ -74,6 +67,8 @@ VALIDATE_SCHEMA = bool(os.environ.get("VALIDATE_SCHEMA"))
 
 ERR_NOT_FOUND = 404
 ERR_CONFLICT = 409
+
+LOGGER = logging.getLogger(__name__)
 
 
 def validate_schema(data):
@@ -211,6 +206,7 @@ def update_config_map(data, name, namespace):
 
 
 def main():
+    configure_logging()
     LOGGER.info(
         "Updating config_map=%s in namespace=%s for product/version=%s/%s",
         CONFIG_MAP, CONFIG_MAP_NAMESPACE, PRODUCT, PRODUCT_VERSION

--- a/cray_product_catalog/logging.py
+++ b/cray_product_catalog/logging.py
@@ -1,0 +1,41 @@
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Logging configuration for cray_product_catalog
+
+import logging
+import sys
+
+
+def configure_logging():
+    """
+    Configure the cray_product_catalog logger.
+    """
+    # Get the package name (e.g. cray_product_catalog)
+    logger_name = __name__.split('.', 1)[0]
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter("%(levelname)s %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)


### PR DESCRIPTION
## Summary and Scope

See commit messages:
* Add log format so that messages are prefixed with severity per IUF guidelines
* Modify license check job so that authenticated access is used to access artifactory.
* Add an environment variable for the removal of the "active" field.

## Issues and Related PRs

* CASM-3698
* CASMINST-5440
* CRAYSAT-1644

## Testing

### Tested on:

* Local development system

### Test description:

See commit messages

## Pull Request Checklist

- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Is a new version being released? Update https://github.com/Cray-HPE/cray-product-catalog/wiki/CSM-Compatibility-Matrix
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable