### PR TITLE
"CASMCMS-8353: Provide authentication environment for cms-metatools"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2022-12-20
+### Added
+- Add Artifactory authentication to Jenkinsfile
+
 ## [Unreleased]
 
 ## [1.7.0] - 2022-11-17

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -64,7 +64,9 @@ pipeline {
 
         stage("runBuildPrep") {
             steps {
-                sh "make runbuildprep"
+                 withCredentials([usernamePassword(credentialsId: 'artifactory-algol60-readonly', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
+                    sh "make runbuildprep"
+                    }
             }
         }
 


### PR DESCRIPTION
## Summary and Scope

CASMCMS-8353: Provide authentication environment for cms-meta-tools

In response to CASMTRIAGE-4680 as well as the tightening of permissions
on CASM's artifactory server, cms-meta-tools was upgraded to authenticate
to both DST's artifactory as well as CASM's artifactory.  To authenticate
to CASM's artifactory, we need to set up the environment with
authentication, i.e. user name and password. This meant	the Jenkinsfiles
had to have this authentication	added.



## Issues and Related PRs

* Resolves CASMCMS-8353

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Build system

### Test description:

We saw that the	build succeeded.


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? No. If this fails, the build fails.
- Was upgrade tested? If not, why? No. Not needed.
- Was downgrade tested? If not, why? No. Not needed.
- Were new tests (or test issues/Jiras) created for this change? No.

## Risks and Mitigations
High. If this does not work, then builds will not work.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
