### PR TITLE
CASM-3589: Remove duplicate entries when merging dictionaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.7.1] - 2022-12-20
-### Added
-- Add Artifactory authentication to Jenkinsfile
-
 ## [Unreleased]
+
+## [1.8.2] - 2023-01-10
+
+### Fixed
+
+- Fixed an issue where inserting certain types of data would loop forever.
+
+## [1.8.1] - 2022-12-20
+
+### Added
+
+- Add Artifactory authentication to Jenkinsfile
 
 ## [1.8.0] - 2022-12-20
 
@@ -303,7 +311,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change default reviewers to CMS-core-product-support
 
-[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.2...HEAD
+
+[1.8.2]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.1...v1.8.2
+
+[1.8.1]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.0...v1.8.1
 
 [1.8.0]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.7.0...v1.8.0
 

--- a/cray_product_catalog/util/merge_dict.py
+++ b/cray_product_catalog/util/merge_dict.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -111,8 +111,10 @@ def _merge_input_with_existing(input_key, input_value, dict_to_update):
             # Merging two dicts, use merge_dict() recursively.
             dict_to_update[input_key] = merge_dict(input_value, dict_to_update[input_key])
         elif _values_are_lists(dict_to_update[input_key], input_value):
-            # Merging two lists, use extend().
-            dict_to_update[input_key].extend(input_value)
+            # Merging two lists, use extend(). Do not duplicate items.
+            dict_to_update[input_key].extend(
+                [val for val in input_value if val not in dict_to_update[input_key]]
+            )
         else:
             if _values_are_different_types(input_value, dict_to_update[input_key]):
                 raise TypeError(

--- a/tests/util/test_merge_dict.py
+++ b/tests/util/test_merge_dict.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -80,3 +80,16 @@ class TestMergeDict(unittest.TestCase):
         merge_dict(input_dict, existing)
         self.assertEqual(input_dict, COMPLICATED_INPUT_DICT)
         self.assertEqual(existing, COMPLICATED_EXISTING_DICT)
+
+    def test_merge_dict_with_duplicate_dicts(self):
+        """Test that merge_dict resolves duplicate dictionaries."""
+        input_dict = deepcopy(PRODUCT_CATALOG_INPUT_DATA)
+        input_dict['component_versions']['docker'].extend([
+            {
+                'name': 'cray-apple',
+                'version': '1.0.0'
+            }
+        ])
+        expected = PRODUCT_CATALOG_EXPECTED_MERGE
+        actual = merge_dict(input_dict, PRODUCT_CATALOG_EXISTING_DATA)
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
This commit changes the behavior of the 'merge_dict' utility, such that duplicate entries in a list are now replaced. Add a unit test for this behavior.

The behavior was changed to prevent an infinite loop in the product catalog update process. The main loop in update_catalog breaks out of the loop only if merging in new content would do nothing (i.e.; it does a merge of the input data into the current catalog data and checks if it was unchanged. However, when merging a dictionary containing lists that do not remove duplicates, the resulting data will always change, leading to the process looping forever.

In addition to this issue in the logic, it probably makes more sense to not allow duplicate lists of dictionaries in the catalog. For example, if a partial install were to insert some of the repositories for a product, we likely would not want to have duplicate entries. This could possibly expose some edge cases involving installing multiple of the same version of a product with changed component data, though this is unlikely to happen in practice.

This commit adds a change log entry and declares a new version.

Test Description:
* Unit test for the utility function.
* I added a unit test on the feature/add-unit-tests branch to test more thoroughly, but have not included it here.
* Using minikube, I tested inserting repository data into a local cray-product-catalog configmap without this change, reproducing the infinite loop, then with this change, showing it could be inserted.

## Summary and Scope

See commit message

## Testing

See commit message

## Pull Request Checklist

- [x] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Is a new version being released? Update https://github.com/Cray-HPE/cray-product-catalog/wiki/CSM-Compatibility-Matrix
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable