### PR TITLE
CASMCMS-8521: Fixed bad image path in chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed bad image path in the helm chart
 
+### Changed
+
+- Updated chart maintainer
+
 ## [1.8.2] - 2023-01-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bad image path in the helm chart
+
 ## [1.8.2] - 2023-01-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated chart maintainer
+- Correct version strings used in Chart
 
 ## [1.8.2] - 2023-01-10
 

--- a/charts/cray-product-catalog/Chart.yaml
+++ b/charts/cray-product-catalog/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-product-catalog
-version: 0.0.0-DEV  # Replaced during build
+version: 0.0.0-chart  # Replaced during build
 description: Catalog of Cray EX add-on Products
 keywords:
   - cray
@@ -33,12 +33,12 @@ sources:
 maintainers:
   - email: mitchell.harding@hpe.com
     name: mharding-hpe
-appVersion: 0.0.0-DEV  # Replaced during build
+appVersion: 0.0.0-docker  # Replaced during build
 annotations:
   # image reference replaced during build
   artifacthub.io/images: |
     - name: cray-product-catalog-update
-      image: artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update:0.0.0
+      image: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-product-catalog-update:0.0.0-docker
     - name: docker-kubectl
       image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
   artifacthub.io/license: MIT

--- a/charts/cray-product-catalog/Chart.yaml
+++ b/charts/cray-product-catalog/Chart.yaml
@@ -31,8 +31,8 @@ keywords:
 sources:
   - https://github.com/Cray-HPE/cray-product-catalog
 maintainers:
-  - email: randy.kleinman@hpe.com
-    name: rkleinman-hpe
+  - email: mitchell.harding@hpe.com
+    name: mharding-hpe
 appVersion: 0.0.0-DEV  # Replaced during build
 annotations:
   # image reference replaced during build

--- a/charts/cray-product-catalog/Chart.yaml
+++ b/charts/cray-product-catalog/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -38,7 +38,7 @@ annotations:
   # image reference replaced during build
   artifacthub.io/images: |
     - name: cray-product-catalog-update
-      image: cray-product-catalog-update:0.0.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update:0.0.0
     - name: docker-kubectl
       image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
   artifacthub.io/license: MIT

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -17,6 +17,18 @@
 
 # This sourcefile does not exist as a static file in the repo.
 # It is created at build time.
+sourcefile: .docker_version
+tag: 0.0.0-docker
+targetfile: charts/cray-product-catalog/Chart.yaml
+
+# This sourcefile does not exist as a static file in the repo.
+# It is created at build time.
 sourcefile: .chart_version
-tag: 0.0.0
+tag: 0.0.0-chart
+targetfile: charts/cray-product-catalog/Chart.yaml
+
+# The following file does not exist in the repo as a static file
+# It is generated at build time
+sourcefile-novalidate: .stable
+tag: S-T-A-B-L-E
 targetfile: charts/cray-product-catalog/Chart.yaml


### PR DESCRIPTION
The helm chart had a bad image path, injected with commit b9df79f175eb93a10511433e44b5e5b555ce70a9
