### PR TITLE
CASM-3973: Adding overwrite update to support key deletions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added `UPDATE_OVERWRITE` environment variable to support cases where
+  full control of the products configmap data is required.
+
 ### Changed
 
 - dependabot: Bump `requests` from 2.30.0 to 2.31.0

--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ All configuration options are provided as environment variables.
  > When set, all versions of the given product will have the 'active' field removed from the
  > ConfigMap data. Cannot be used with `SET_ACTIVE_VERSION` (see above).
 
+ * `UPDATE_OVERWRITE` = `''`
+
+> When set, the catalog_update function will perform an update that will
+> overwrite the keys in the config map. Contrasted to the default implementation
+> which will perform a merge operation between the two maps.
+> This is useful for removing nested data or just simply removing entire
+> entries from the config map.
+
 ## Versioning and Releases
 
 Versions are calculated automatically using `gitversion`. The full SemVer

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ All configuration options are provided as environment variables.
  * `UPDATE_OVERWRITE` = `''`
 
 > When set, the catalog_update function will perform an update that will
-> overwrite the keys in the config map. Contrasted to the default implementation
+> overwrite the entire product data in the configmap. Contrasted to the default implementation
 > which will perform a merge operation between the two maps.
 > This is useful for removing nested data or just simply removing entire
 > entries from the config map.

--- a/cray_product_catalog/catalog_update.py
+++ b/cray_product_catalog/catalog_update.py
@@ -129,6 +129,7 @@ def active_field_exists(product_data):
     """ Return True if any version of the given product is using the 'active' field."""
     return any("active" in product_data[version] for version in product_data)
 
+
 def update_config_map(data: dict, name, namespace):
     """
     Get the config map `data` to be added.
@@ -193,7 +194,8 @@ def update_config_map(data: dict, name, namespace):
                 if UPDATE_OVERWRITE:
                     product_data[PRODUCT_VERSION] = data
                 else:
-                    merged_product_data = merge_dict(data, product_data[PRODUCT_VERSION]) == product_data[PRODUCT_VERSION]
+                    merged_product_data = merge_dict(
+                        data, product_data[PRODUCT_VERSION]) == product_data[PRODUCT_VERSION]
 
                 if merged_product_data or UPDATE_OVERWRITE:
                     if SET_ACTIVE_VERSION and REMOVE_ACTIVE_FIELD:

--- a/cray_product_catalog/catalog_update.py
+++ b/cray_product_catalog/catalog_update.py
@@ -35,21 +35,21 @@ import logging
 import os
 import random
 import time
-import urllib3
-from urllib3.util.retry import Retry
 
+import urllib3
+import yaml
 from jsonschema.exceptions import ValidationError
-from kubernetes import client
 from kubernetes.client.api_client import ApiClient
 from kubernetes.client.models.v1_config_map import V1ConfigMap
 from kubernetes.client.models.v1_object_meta import V1ObjectMeta
 from kubernetes.client.rest import ApiException
-import yaml
+from urllib3.util.retry import Retry
 
 from cray_product_catalog.logging import configure_logging
 from cray_product_catalog.schema.validate import validate
 from cray_product_catalog.util.k8s import load_k8s
 from cray_product_catalog.util.merge_dict import merge_dict
+from kubernetes import client
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -65,6 +65,7 @@ YAML_CONTENT_STRING = os.environ.get("YAML_CONTENT_STRING", "").strip()   # see 
 SET_ACTIVE_VERSION = bool(os.environ.get("SET_ACTIVE_VERSION"))
 REMOVE_ACTIVE_FIELD = bool(os.environ.get("REMOVE_ACTIVE_FIELD"))
 VALIDATE_SCHEMA = bool(os.environ.get("VALIDATE_SCHEMA"))
+UPDATE_OVERWRITE = bool(os.environ.get("UPDATE_OVERWRITE"))
 
 ERR_NOT_FOUND = 404
 ERR_CONFLICT = 409
@@ -128,8 +129,7 @@ def active_field_exists(product_data):
     """ Return True if any version of the given product is using the 'active' field."""
     return any("active" in product_data[version] for version in product_data)
 
-
-def update_config_map(data, name, namespace):
+def update_config_map(data: dict, name, namespace):
     """
     Get the config map `data` to be added.
 
@@ -189,7 +189,13 @@ def update_config_map(data, name, namespace):
             # Key with same version exists in ConfigMap
             else:
                 # Data to insert matches data found in configmap.
-                if merge_dict(data, product_data[PRODUCT_VERSION]) == product_data[PRODUCT_VERSION]:
+                merged_product_data = None
+                if UPDATE_OVERWRITE:
+                    product_data[PRODUCT_VERSION] = data
+                else:
+                    merged_product_data = merge_dict(data, product_data[PRODUCT_VERSION]) == product_data[PRODUCT_VERSION]
+
+                if merged_product_data or UPDATE_OVERWRITE:
                     if SET_ACTIVE_VERSION and REMOVE_ACTIVE_FIELD:
                         # This should not happen (see main method).
                         raise SystemExit(1)


### PR DESCRIPTION
## Summary and Scope

The config map needs to support functionality that allows the keys to be overwritten when necessary. This is to allow scenarios where deleting a single key from the config is possible without having to perform a full delete of the map and then update.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves https://jira-pro.it.hpe.com:8443/browse/CASM-3973

## Testing

### Tested on:

  * `Mug`

Removal of nexus helm charts and configmap updates.

## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Is a new version being released? Update https://github.com/Cray-HPE/cray-product-catalog/wiki/CSM-Compatibility-Matrix
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

