### PR TITLE
Release 1.8.9

### DIFF
--- a/.github/workflows/charts-lint-test-scan.yml
+++ b/.github/workflows/charts-lint-test-scan.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v35
+      uses: tj-actions/changed-files@v36
 
     - name: License Check
       if: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v36
+      uses: tj-actions/changed-files@v37
 
     - name: License Check
       if: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - dependabot: Bump `requests` from 2.30.0 to 2.31.0
 - dependabot: Bump `google-auth` from 2.17.3 to 2.20.0
+- dependabot: Bump `cachetools` from 5.3.0 to 5.3.1
 
 ## [1.8.8] - 2023-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- dependabot: Bump `requests` from 2.30.0 to 2.31.0
+
 ## [1.8.8] - 2023-05-31
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.9] - 2023-07-05
+
 ### Added
 
 - Added `UPDATE_OVERWRITE` environment variable to support cases where
@@ -18,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - dependabot: Bump `google-auth` from 2.17.3 to 2.21.0
 - dependabot: Bump `cachetools` from 5.3.0 to 5.3.1
 - dependabot: Bump `websocket-client` from 1.5.2 to 1.6.1
+- Added `UPDATE_OVERWRITE` environment variable to support cases where
+  full control of the products configmap data is required.
 
 ## [1.8.8] - 2023-05-31
 
@@ -381,7 +385,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change default reviewers to CMS-core-product-support
 
-[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.8...HEAD
+[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.9...HEAD
+
+[1.8.9]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.8...v1.8.9
 
 [1.8.8]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.7...v1.8.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
 - Added `UPDATE_OVERWRITE` environment variable to support cases where
   full control of the products configmap data is required.
 
 ### Changed
 
 - dependabot: Bump `requests` from 2.30.0 to 2.31.0
-- dependabot: Bump `google-auth` from 2.17.3 to 2.20.0
+- dependabot: Bump `google-auth` from 2.17.3 to 2.21.0
 - dependabot: Bump `cachetools` from 5.3.0 to 5.3.1
 - dependabot: Bump `websocket-client` from 1.5.2 to 1.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - dependabot: Bump `requests` from 2.30.0 to 2.31.0
 - dependabot: Bump `google-auth` from 2.17.3 to 2.20.0
 - dependabot: Bump `cachetools` from 5.3.0 to 5.3.1
+- dependabot: Bump `websocket-client` from 1.5.2 to 1.6.1
 
 ## [1.8.8] - 2023-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - dependabot: Bump `requests` from 2.30.0 to 2.31.0
+- dependabot: Bump `google-auth` from 2.17.3 to 2.20.0
 
 ## [1.8.8] - 2023-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added `UPDATE_OVERWRITE` environment variable to support cases where
+  full control of the products configmap data is required.
+
 ### Changed
 
 - dependabot: Bump `requests` from 2.30.0 to 2.31.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - dependabot: Bump `pyasn1-modules` from 0.2.8 to 0.3.0
 - dependabot: Bump `pyasn1` from 0.4.8 to 0.5.0
 - dependabot: Bump `attrs` from 22.2.0 to 23.1.0
+- dependabot: Bump `requests` from 2.28.2 to 2.30.0
 
 ## [1.8.6] - 2023-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - dependabot: Bump `kubernetes` from 23.3.0 to 26.1.0
 - dependabot: Bump `certifi` from 2021.10.8 to 2022.12.7
 - dependabot: Bump `oauthlib` from 3.2.0 to 3.2.2
+- dependabot: Bump `rsa` from 4.8 to 4.9
 
 ## [1.8.5] - 2023-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- dependabot: Bump `websocket-client` from 1.5.1 to 1.5.2
+
 ## [1.8.7] - 2023-05-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,26 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump `jsonschema` from 4.4.0 to 4.17.3
-- Bump `kubernetes` from 23.3.0 to 26.1.0
-- Bump `certifi` from 2021.10.8 to 2022.12.7
+- dependabot: Bump `jsonschema` from 4.4.0 to 4.17.3
+- dependabot: Bump `kubernetes` from 23.3.0 to 26.1.0
+- dependabot: Bump `certifi` from 2021.10.8 to 2022.12.7
+- dependabot: Bump `oauthlib` from 3.2.0 to 3.2.2
 
 ## [1.8.5] - 2023-04-11
 
 ### Changed
 
-- Bump `charset-normalizer` from 2.0.12 to 3.1.0.
-- Bump `attrs` from 21.4.0 to 22.2.0.
-- Bump `pyrsistent` from 0.18.1 to 0.19.3.
-- Bump `requests` from 2.27.1 to 2.28.2
+- dependabot: Bump `charset-normalizer` from 2.0.12 to 3.1.0.
+- dependabot: Bump `attrs` from 21.4.0 to 22.2.0.
+- dependabot: Bump `pyrsistent` from 0.18.1 to 0.19.3.
+- dependabot: Bump `requests` from 2.27.1 to 2.28.2
 
 ## [1.8.4] - 2023-04-07
 
 ### Changed
 
-- Bump `google-auth` from 2.6.0 to 2.17.2
-- Bump `websocket-client` from 1.3.1 to 1.5.1
-- Bump `urllib3` from 1.26.8 to 1.26.15
+- dependabot: Bump `google-auth` from 2.6.0 to 2.17.2
+- dependabot: Bump `websocket-client` from 1.3.1 to 1.5.1
+- dependabot: Bump `urllib3` from 1.26.8 to 1.26.15
 
 ## [1.8.3] - 2023-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - dependabot: Bump `certifi` from 2021.10.8 to 2022.12.7
 - dependabot: Bump `oauthlib` from 3.2.0 to 3.2.2
 - dependabot: Bump `rsa` from 4.8 to 4.9
+- dependabot: Bump `idna` from 3.3 to 3.4
 
 ## [1.8.5] - 2023-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.6] - 2023-04-24
+
 ### Changed
 
 - dependabot: Bump `jsonschema` from 4.4.0 to 4.17.3
@@ -350,7 +352,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change default reviewers to CMS-core-product-support
 
-[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.5...HEAD
+[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.6...HEAD
+
+[1.8.6]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.5...v1.8.6
 
 [1.8.5]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.4...v1.8.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `jsonschema` from 4.4.0 to 4.17.3
 - Bump `kubernetes` from 23.3.0 to 26.1.0
+- Bump `certifi` from 2021.10.8 to 2022.12.7
 
 ## [1.8.5] - 2023-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - dependabot: Bump `pyasn1-modules` from 0.2.8 to 0.3.0
+- dependabot: Bump `pyasn1` from 0.4.8 to 0.5.0
 
 ## [1.8.6] - 2023-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - dependabot: Bump `pyasn1-modules` from 0.2.8 to 0.3.0
 - dependabot: Bump `pyasn1` from 0.4.8 to 0.5.0
+- dependabot: Bump `attrs` from 22.2.0 to 23.1.0
 
 ## [1.8.6] - 2023-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - dependabot: Bump `pyasn1` from 0.4.8 to 0.5.0
 - dependabot: Bump `attrs` from 22.2.0 to 23.1.0
 - dependabot: Bump `requests` from 2.28.2 to 2.30.0
+- dependabot: Bump `certifi` from 2022.12.7 to 2023.5.7
 
 ## [1.8.6] - 2023-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - dependabot: Bump `oauthlib` from 3.2.0 to 3.2.2
 - dependabot: Bump `rsa` from 4.8 to 4.9
 - dependabot: Bump `idna` from 3.3 to 3.4
+- dependabot: Bump `cachetools` from 5.0.0 to 5.3.0
 
 ## [1.8.5] - 2023-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.8] - 2023-05-31
+
 ### Changed
 
 - dependabot: Bump `websocket-client` from 1.5.1 to 1.5.2
+- CASM-4224: Improve logging for [`catalog_update.py`](cray_product_catalog/catalog_update.py) for use with IUF.
 
 ## [1.8.7] - 2023-05-08
 
@@ -366,7 +369,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change default reviewers to CMS-core-product-support
 
-[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.7...HEAD
+[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.8...HEAD
+
+[1.8.8]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.7...v1.8.8
 
 [1.8.7]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.6...v1.8.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.7] - 2023-05-08
+
 ### Changed
 
 - dependabot: Bump `pyasn1-modules` from 0.2.8 to 0.3.0
@@ -360,7 +362,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change default reviewers to CMS-core-product-support
 
-[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.6...HEAD
+[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.7...HEAD
+
+[1.8.7]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.6...v1.8.7
 
 [1.8.6]: https://github.com/Cray-HPE/cray-product-catalog/compare/v1.8.5...v1.8.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `jsonschema` from 4.4.0 to 4.17.3
+- Bump `kubernetes` from 23.3.0 to 26.1.0
 
 ## [1.8.5] - 2023-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- dependabot: Bump `pyasn1-modules` from 0.2.8 to 0.3.0
+
 ## [1.8.6] - 2023-04-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - dependabot: Bump `rsa` from 4.8 to 4.9
 - dependabot: Bump `idna` from 3.3 to 3.4
 - dependabot: Bump `cachetools` from 5.0.0 to 5.3.0
+- dependabot: Bump `google-auth` from 2.17.2 to 2.17.3
 
 ## [1.8.5] - 2023-04-11
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ All configuration options are provided as environment variables.
  > When set, all versions of the given product will have the 'active' field removed from the
  > ConfigMap data. Cannot be used with `SET_ACTIVE_VERSION` (see above).
 
+ * `UPDATE_OVERWRITE` = `''`
+
+> When set, the catalog_update function will perform an update that will
+> overwrite the entire product data in the configmap. Contrasted to the default implementation
+> which will perform a merge operation between the two maps.
+> This is useful for removing nested data or just simply removing entire
+> entries from the config map.
+
 ## Versioning and Releases
 
 Versions are calculated automatically using `gitversion`. The full SemVer

--- a/constraints.txt
+++ b/constraints.txt
@@ -17,4 +17,4 @@ requests-oauthlib==1.3.1
 rsa==4.9
 six==1.16.0
 urllib3==1.26.15
-websocket-client==1.5.2
+websocket-client==1.6.1

--- a/constraints.txt
+++ b/constraints.txt
@@ -2,7 +2,7 @@ attrs==23.1.0
 cachetools==5.3.1
 certifi==2023.5.7
 charset-normalizer==3.1.0
-google-auth==2.20.0
+google-auth==2.21.0
 idna==3.4
 jsonschema==4.17.3
 kubernetes==26.1.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -12,7 +12,7 @@ pyasn1-modules==0.3.0
 pyrsistent==0.19.3
 python-dateutil==2.8.2
 PyYAML==6.0
-requests==2.30.0
+requests==2.31.0
 requests-oauthlib==1.3.1
 rsa==4.9
 six==1.16.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,5 +1,5 @@
 attrs==23.1.0
-cachetools==5.3.0
+cachetools==5.3.1
 certifi==2023.5.7
 charset-normalizer==3.1.0
 google-auth==2.20.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -2,7 +2,7 @@ attrs==23.1.0
 cachetools==5.3.0
 certifi==2023.5.7
 charset-normalizer==3.1.0
-google-auth==2.17.3
+google-auth==2.20.0
 idna==3.4
 jsonschema==4.17.3
 kubernetes==26.1.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,6 +1,6 @@
 attrs==23.1.0
 cachetools==5.3.0
-certifi==2022.12.7
+certifi==2023.5.7
 charset-normalizer==3.1.0
 google-auth==2.17.3
 idna==3.4

--- a/constraints.txt
+++ b/constraints.txt
@@ -6,7 +6,7 @@ google-auth==2.17.2
 idna==3.3
 jsonschema==4.17.3
 kubernetes==26.1.0
-oauthlib==3.2.0
+oauthlib==3.2.2
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pyrsistent==0.19.3

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,5 +1,5 @@
 attrs==22.2.0
-cachetools==5.0.0
+cachetools==5.3.0
 certifi==2022.12.7
 charset-normalizer==3.1.0
 google-auth==2.17.2

--- a/constraints.txt
+++ b/constraints.txt
@@ -7,7 +7,7 @@ idna==3.4
 jsonschema==4.17.3
 kubernetes==26.1.0
 oauthlib==3.2.2
-pyasn1==0.4.8
+pyasn1==0.5.0
 pyasn1-modules==0.3.0
 pyrsistent==0.19.3
 python-dateutil==2.8.2

--- a/constraints.txt
+++ b/constraints.txt
@@ -5,7 +5,7 @@ charset-normalizer==3.1.0
 google-auth==2.17.2
 idna==3.3
 jsonschema==4.17.3
-kubernetes==23.3.0
+kubernetes==26.1.0
 oauthlib==3.2.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8

--- a/constraints.txt
+++ b/constraints.txt
@@ -17,4 +17,4 @@ requests-oauthlib==1.3.1
 rsa==4.9
 six==1.16.0
 urllib3==1.26.15
-websocket-client==1.5.1
+websocket-client==1.5.2

--- a/constraints.txt
+++ b/constraints.txt
@@ -12,7 +12,7 @@ pyasn1-modules==0.3.0
 pyrsistent==0.19.3
 python-dateutil==2.8.2
 PyYAML==6.0
-requests==2.28.2
+requests==2.30.0
 requests-oauthlib==1.3.1
 rsa==4.9
 six==1.16.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -3,7 +3,7 @@ cachetools==5.0.0
 certifi==2022.12.7
 charset-normalizer==3.1.0
 google-auth==2.17.2
-idna==3.3
+idna==3.4
 jsonschema==4.17.3
 kubernetes==26.1.0
 oauthlib==3.2.2

--- a/constraints.txt
+++ b/constraints.txt
@@ -2,7 +2,7 @@ attrs==22.2.0
 cachetools==5.3.0
 certifi==2022.12.7
 charset-normalizer==3.1.0
-google-auth==2.17.2
+google-auth==2.17.3
 idna==3.4
 jsonschema==4.17.3
 kubernetes==26.1.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,6 +1,6 @@
 attrs==22.2.0
 cachetools==5.0.0
-certifi==2021.10.8
+certifi==2022.12.7
 charset-normalizer==3.1.0
 google-auth==2.17.2
 idna==3.3

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,4 @@
-attrs==22.2.0
+attrs==23.1.0
 cachetools==5.3.0
 certifi==2022.12.7
 charset-normalizer==3.1.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -14,7 +14,7 @@ python-dateutil==2.8.2
 PyYAML==6.0
 requests==2.28.2
 requests-oauthlib==1.3.1
-rsa==4.8
+rsa==4.9
 six==1.16.0
 urllib3==1.26.15
 websocket-client==1.5.1

--- a/constraints.txt
+++ b/constraints.txt
@@ -8,7 +8,7 @@ jsonschema==4.17.3
 kubernetes==26.1.0
 oauthlib==3.2.2
 pyasn1==0.4.8
-pyasn1-modules==0.2.8
+pyasn1-modules==0.3.0
 pyrsistent==0.19.3
 python-dateutil==2.8.2
 PyYAML==6.0

--- a/cray_product_catalog/catalog_update.py
+++ b/cray_product_catalog/catalog_update.py
@@ -35,21 +35,21 @@ import logging
 import os
 import random
 import time
-import urllib3
-from urllib3.util.retry import Retry
 
+import urllib3
+import yaml
 from jsonschema.exceptions import ValidationError
-from kubernetes import client
 from kubernetes.client.api_client import ApiClient
 from kubernetes.client.models.v1_config_map import V1ConfigMap
 from kubernetes.client.models.v1_object_meta import V1ObjectMeta
 from kubernetes.client.rest import ApiException
-import yaml
+from urllib3.util.retry import Retry
 
 from cray_product_catalog.logging import configure_logging
 from cray_product_catalog.schema.validate import validate
 from cray_product_catalog.util.k8s import load_k8s
 from cray_product_catalog.util.merge_dict import merge_dict
+from kubernetes import client
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -65,6 +65,7 @@ YAML_CONTENT_STRING = os.environ.get("YAML_CONTENT_STRING", "").strip()   # see 
 SET_ACTIVE_VERSION = bool(os.environ.get("SET_ACTIVE_VERSION"))
 REMOVE_ACTIVE_FIELD = bool(os.environ.get("REMOVE_ACTIVE_FIELD"))
 VALIDATE_SCHEMA = bool(os.environ.get("VALIDATE_SCHEMA"))
+UPDATE_OVERWRITE = bool(os.environ.get("UPDATE_OVERWRITE"))
 
 ERR_NOT_FOUND = 404
 ERR_CONFLICT = 409
@@ -129,7 +130,7 @@ def active_field_exists(product_data):
     return any("active" in product_data[version] for version in product_data)
 
 
-def update_config_map(data, name, namespace):
+def update_config_map(data: dict, name, namespace):
     """
     Get the config map `data` to be added.
 
@@ -189,7 +190,14 @@ def update_config_map(data, name, namespace):
             # Key with same version exists in ConfigMap
             else:
                 # Data to insert matches data found in configmap.
-                if merge_dict(data, product_data[PRODUCT_VERSION]) == product_data[PRODUCT_VERSION]:
+                merged_product_data = None
+                if UPDATE_OVERWRITE:
+                    product_data[PRODUCT_VERSION] = data
+                else:
+                    merged_product_data = merge_dict(
+                        data, product_data[PRODUCT_VERSION]) == product_data[PRODUCT_VERSION]
+
+                if merged_product_data or UPDATE_OVERWRITE:
                     if SET_ACTIVE_VERSION and REMOVE_ACTIVE_FIELD:
                         # This should not happen (see main method).
                         raise SystemExit(1)

--- a/cray_product_catalog/catalog_update.py
+++ b/cray_product_catalog/catalog_update.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -74,8 +74,8 @@ LOGGER = logging.getLogger(__name__)
 
 def validate_schema(data):
     """ Validate data against the schema. """
-    LOGGER.info(
-        "Validating data against schema because VALIDATE_SCHEMA was set."
+    LOGGER.debug(
+        "Validating data against schema because VALIDATE_SCHEMA was set"
     )
     try:
         validate(data)
@@ -86,14 +86,14 @@ def validate_schema(data):
 
 def read_yaml_content(yaml_file):
     """ Read and return the raw content contained in the `yaml_file`. """
-    LOGGER.info("Retrieving content from %s", yaml_file)
+    LOGGER.debug("Retrieving content from %s", yaml_file)
     with open(yaml_file) as yfile:
         return yaml.safe_load(yfile)
 
 
 def read_yaml_content_string(yaml_string):
     """ Read and return the raw content contained in the `yaml_string` string. """
-    LOGGER.info("Retrieving raw content specified as a string")
+    LOGGER.debug("Retrieving raw content specified as a string")
     return yaml.safe_load(yaml_string)
 
 
@@ -157,7 +157,7 @@ def update_config_map(data, name, namespace):
         # exist yet
         attempt += 1
         sleepy_time = random.randint(1, 3)
-        LOGGER.info("Resting %ss before reading ConfigMap", sleepy_time)
+        LOGGER.debug("Resting %ss before reading ConfigMap", sleepy_time)
         time.sleep(sleepy_time)
 
         # Read in the config map
@@ -168,7 +168,7 @@ def update_config_map(data, name, namespace):
 
             # Config map doesn't exist yet
             if e.status == ERR_NOT_FOUND:
-                LOGGER.warning("ConfigMap %s/%s doesn't exist, attempting again.", namespace, name)
+                LOGGER.warning("ConfigMap %s/%s doesn't exist, attempting again", namespace, name)
                 continue
             else:
                 raise  # unrecoverable
@@ -195,14 +195,14 @@ def update_config_map(data, name, namespace):
                         raise SystemExit(1)
                     elif SET_ACTIVE_VERSION:
                         if current_version_is_active(product_data):
-                            LOGGER.info("ConfigMap data updates exist and desired version is active; Exiting.")
+                            LOGGER.debug("ConfigMap data updates exist and desired version is active; Exiting")
                             break
                     elif REMOVE_ACTIVE_FIELD:
                         if not active_field_exists(product_data):
-                            LOGGER.info("ConfigMap data updates exist and 'active' field has been cleared; Exiting.")
+                            LOGGER.debug("ConfigMap data updates exist and 'active' field has been cleared; Exiting")
                             break
                     else:
-                        LOGGER.info("ConfigMap data updates exist; Exiting.")
+                        LOGGER.debug("ConfigMap data updates exist; Exiting")
                         break
 
         # Patch the config map if needed
@@ -214,7 +214,7 @@ def update_config_map(data, name, namespace):
         config_map_data[PRODUCT] = yaml.safe_dump(
             product_data, default_flow_style=False
         )
-        LOGGER.info("ConfigMap update attempt=%s", attempt)
+        LOGGER.debug("ConfigMap update attempt=%s", attempt)
         try:
             new_config_map = V1ConfigMap(data=config_map_data)
             new_config_map.metadata = V1ObjectMeta(
@@ -242,19 +242,19 @@ def main():
 
     if SET_ACTIVE_VERSION and REMOVE_ACTIVE_FIELD:
         LOGGER.error(
-            "SET_ACTIVE_VERSION and REMOVE_ACTIVE_FIELD cannot both be set."
+            "SET_ACTIVE_VERSION and REMOVE_ACTIVE_FIELD cannot both be set"
         )
         raise SystemExit(1)
 
     elif SET_ACTIVE_VERSION:
         LOGGER.info(
-            "Setting %s:%s to active because SET_ACTIVE_VERSION was set.",
+            "Setting %s:%s to active because SET_ACTIVE_VERSION was set",
             PRODUCT, PRODUCT_VERSION
         )
 
     elif REMOVE_ACTIVE_FIELD:
         LOGGER.info(
-            "Product %s will have 'active' value cleared because REMOVE_ACTIVE_FIELD was set.", PRODUCT
+            "Product %s will have 'active' value cleared because REMOVE_ACTIVE_FIELD was set", PRODUCT
         )
 
     load_k8s()
@@ -265,7 +265,7 @@ def main():
     else:
         LOGGER.error(
             "One of the environment variables YAML_CONTENT_FILE or "
-            "YAML_CONTENT_STRING must be specified."
+            "YAML_CONTENT_STRING must be specified"
         )
         raise SystemExit(1)
     if VALIDATE_SCHEMA:


### PR DESCRIPTION
## Summary and Scope
Release notes:
- dependabot: Bump `requests` from 2.30.0 to 2.31.0
- dependabot: Bump `google-auth` from 2.17.3 to 2.20.0
- dependabot: Bump `cachetools` from 5.3.0 to 5.3.1
- dependabot: Bump `websocket-client` from 1.5.2 to 1.6.1
- Added `UPDATE_OVERWRITE` environment variable to support cases where
  full control of the products configmap data is required.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves partially [CASM-3973](https://jira-pro.it.hpe.com:8443/browse/CASM-3973)
* Merge before `https://github.com/Cray-HPE/shasta-install-utility-common/pull/8`
