### PR TITLE
CASMCMS-8713: Temporarily modify PyYAML, kubernetes install procedure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Dependencies
 - Bump `google-auth` from 2.21.0 to 2.22.0 (#258)
 - Bump `jsonschema` from 4.18.0 to 4.18.2 (#259)
+- Temporarily modify [`Dockerfile`](Dockerfile) procedure used to install `PyYAML` and `kubernetes`, to work around https://github.com/yaml/pyyaml/issues/601 (#263)
 
 ## [1.8.11] - 2023-07-10
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,37 @@ ARG PYMOD_VERSION=0.0.0
 
 WORKDIR /src/
 COPY cray_product_catalog/ ./cray_product_catalog
-COPY setup.py requirements.txt constraints.txt README.md ./
+
+# The addition of the requirements-pyyaml.txt and requirements-non-pyyaml.txt files is to work around
+# a problem installing the PyYAML Python module. A change was also made to the pip3 install commands to
+# use these files. This work around essentially forces the install of the PyYAML module to use a
+# version of Cython that is < 3.0 (this restriction was added to constraints.txt along with the changes
+# here in the Dockerfile).
+#
+# These workarounds are necessary until one of the following things happens:
+# * PyYAML publishes an update which constrains its build environment to using Cython < 3.0, so that
+#   we don't have to manually impose that constraint.
+# * A combination of Cython and PyYAML versions are released that allow PyYAML to build under Alpine using
+#   Cython >= 3.0, so that we don't need to manually constrain the Cython version.
+# * A PyYAML wheel is available for Alpine, so that the build environment is a non-issue.
+#
+# Currently there is a PyYAML PR up which would do the first item on that list: https://github.com/yaml/pyyaml/pull/702
+# If that PR merges and is added to a PyYAML release, then the following steps should be done to undo the workaround:
+#
+# * Update constraints.txt with the PyYAML version that contains the workaround
+# * Delete requirements-pyyaml.txt requirements-non-pyyaml.txt from the repository
+# * Remove requirements-pyyaml.txt requirements-non-pyyaml.txt from the COPY line in this Dockerfile
+# * Remove the Cython constraint from constraints.txt
+# * Modify the following Dockerfile lines from:
+#
+#    && pip3 install --ignore-installed --no-cache-dir -r requirements-pyyaml.txt --no-build-isolation \
+#    && pip3 install --ignore-installed --no-cache-dir -r requirements-non-pyyaml.txt \
+#
+#   to:
+#
+#    && pip3 install --ignore-installed --no-cache-dir -r requirements.txt \
+#
+COPY setup.py requirements.txt constraints.txt requirements-pyyaml.txt requirements-non-pyyaml.txt README.md ./
 RUN echo ${PYMOD_VERSION} > .version
 
 RUN apk add --upgrade --no-cache apk-tools \
@@ -37,8 +67,9 @@ RUN apk add --upgrade --no-cache apk-tools \
         python3-dev \
         libc-dev \
     && apk -U upgrade --no-cache \
-    && pip3 install --upgrade pip \
-    && pip3 install --ignore-installed --no-cache-dir -r requirements.txt \
+    && pip3 install --upgrade pip wheel \
+    && pip3 install --ignore-installed --no-cache-dir -r requirements-pyyaml.txt --no-build-isolation \
+    && pip3 install --ignore-installed --no-cache-dir -r requirements-non-pyyaml.txt \
     && python3 setup.py install \
     && rm -rf /src/
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -2,6 +2,7 @@ attrs==23.1.0
 cachetools==5.3.1
 certifi==2023.5.7
 charset-normalizer==3.2.0
+Cython<3.0
 google-auth==2.22.0
 idna==3.4
 jsonschema==4.18.2

--- a/requirements-non-pyyaml.txt
+++ b/requirements-non-pyyaml.txt
@@ -1,0 +1,4 @@
+-c constraints.txt
+
+jsonschema
+urllib3

--- a/requirements-pyyaml.txt
+++ b/requirements-pyyaml.txt
@@ -1,0 +1,5 @@
+-c constraints.txt
+
+Cython
+PyYAML
+kubernetes


### PR DESCRIPTION
## Summary and Scope

Cray Product Catalog builds started failing recently, due to https://github.com/yaml/pyyaml/issues/601. Because CPC is using an Alpine container, and because the `kubernetes` Python module has a dependency on `PyYAML` >= 5.4, this PR represents the simplest workaround I was able to come up with. (Essentially, it forces the install of `PyYAML` inside the Docker container to use an older version of Cython). The PR is careful to only make this change when installing the `PyYAML` module and (because it has a dependency on `PyYAML`) the `kubernetes` module. I tried doing it with the modification limited to the `PyYAML` module, but the problem persisted until I pulled the `kubernetes` module in as well.

This should only be a temporary workaround. There is a PR up for `PyYAML` that will allow us to remove this workaround, but it's not clear when it will be merged and released. That PR is: https://github.com/yaml/pyyaml/pull/702

This CPC workaround PR should have no functional impact on CPC. It will just allow the builds to continue working.

## Issues and Related PRs

* https://github.com/yaml/pyyaml/issues/601
* https://github.com/yaml/pyyaml/pull/702
* Works around build failures documented in [CASMCMS-8713](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8713)

## Testing

None beyond making sure the build worked (which itself includes a run of the regression tests).

## Risks and Mitigations

Without this, the CPC is unbuildable.
