### PR TITLE
CASM-4350: Changes in Update code path to accommodate Split config maps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - CASM-4350: Resolve 1MB size limitation of K8s Configmap cray-product-catalog by splitting 
-  it's content across sub/product configmaps
+  it's content to store component-versions field in sub/product configmaps
 
 ## [1.8.12] - 2023-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CASM-4350: Resolve 1MB size limitation of K8s Configmap cray-product-catalog by splitting 
+  it's content across sub/product configmaps
+
 ## [1.8.12] - 2023-07-18
 
 ### Dependencies

--- a/cray_product_catalog/constants.py
+++ b/cray_product_catalog/constants.py
@@ -30,3 +30,4 @@ PRODUCT_CATALOG_CONFIG_MAP_NAMESPACE = 'services'
 COMPONENT_VERSIONS_PRODUCT_MAP_KEY = 'component_versions'
 COMPONENT_REPOS_KEY = 'repositories'
 COMPONENT_DOCKER_KEY = 'docker'
+PRODUCT_CM_FIELDS = {'component_versions'}

--- a/cray_product_catalog/util/catalog_data_helper.py
+++ b/cray_product_catalog/util/catalog_data_helper.py
@@ -1,0 +1,65 @@
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Contains a utility function for merging two dictionaries together.
+
+import re
+
+from cray_product_catalog.constants import (
+    PRODUCT_CM_FIELDS
+)
+
+
+def split_catalog_data(data):
+    """Split the passed data into data needed by main and product config map"""
+    all_unique_keys = set(data.keys())
+    comm_keys_bw_cms = all_unique_keys.intersection(PRODUCT_CM_FIELDS)
+
+    # If fields in PRODUCT_CM_FIELDS is not available in all unique keys return empty dict as second return value
+    if not comm_keys_bw_cms:
+        return {key: data[key] for key in all_unique_keys - PRODUCT_CM_FIELDS}, {}
+    else:
+        return {key: data[key] for key in all_unique_keys - PRODUCT_CM_FIELDS}, \
+            {key: data[key] for key in comm_keys_bw_cms}
+
+
+def format_product_cm_name(config_map, product):
+    """Formatting PRODUCT_CONFIG_NAME based on the product name passed and the same is used as key under data in cm.
+    Below are the rules for configmap name. The name of a ConfigMap must be a valid DNS subdomain name.
+    - contain no more than 253 characters
+    - contain only lowercase alphanumeric characters, '-' or '.'
+    - start with an alphanumeric character
+    - end with an alphanumeric character
+    Rules for Product name which is a key under the data
+    - must be alphanumeric characters, -, _ or .
+    Since product name can have upper case and '_' which are prohibited in config name,
+    we are converting '_' to '-' and upper case to lower case
+    """
+    pat = re.compile('^([a-z0-9])*[a-z0-9.-]*([a-z0-9])$')
+    prod_config_map = config_map + '-' + product.replace('_', '-').lower()
+
+    if len(prod_config_map) > 253:
+        return ''
+    elif not re.fullmatch(pat, prod_config_map):
+        return ''
+    else:
+        return prod_config_map

--- a/tests/util/test_data_catalog_helper.py
+++ b/tests/util/test_data_catalog_helper.py
@@ -1,0 +1,224 @@
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Unit tests for the cray_product_catalog.util.catalog_data_helper module
+"""
+
+import yaml
+import datetime
+from typing import Dict
+from cray_product_catalog.util.catalog_data_helper import split_catalog_data, format_product_cm_name
+
+# Data for testing
+yaml_data = """
+  active: false
+  component_versions:
+    docker:
+    - name: artifactory.algol60.net/uan-docker/stable/cray-uan-config
+      version: 1.11.1
+    - name: artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update
+      version: 1.3.2
+    helm:
+    - name: cray-uan-install
+      version: 1.11.1
+    repositories:
+    - members:
+      - uan-2.6.0-sle-15sp4
+      name: uan-2.6-sle-15sp4
+      type: group
+    manifests:
+    - config-data/argo/loftsman/uan/2.6.0-rc.1/manifests/uan.yaml
+  configuration:
+    clone_url: https://vcs.cmn.lemondrop.hpc.amslabs.hpecorp.net/vcs/cray/uan-config-management.git
+    commit: 6a5f52dfbfe7ea1a5f8ea5079c50995112c17025
+    import_branch: cray/uan/2.6.0-rc.1-3-gcc65df9
+    import_date: 2023-04-12 14:31:40.364230
+    ssh_url: git@vcs.cmn.lemondrop.hpc.amslabs.hpecorp.net:cray/uan-config-management.git
+    images:
+      cray-application-sles15sp4.x86_64-0.5.19:
+        id: 8159f93f-7e18-4875-a8a8-b0fb83c48f07"""
+
+yaml_data_missing_prod_cm_data = """
+  active: false
+  configuration:
+    clone_url: https://vcs.cmn.lemondrop.hpc.amslabs.hpecorp.net/vcs/cray/uan-config-management.git
+    commit: 6a5f52dfbfe7ea1a5f8ea5079c50995112c17025
+    import_branch: cray/uan/2.6.0-rc.1-3-gcc65df9
+    import_date: 2023-04-12 14:31:40.364230
+    ssh_url: git@vcs.cmn.lemondrop.hpc.amslabs.hpecorp.net:cray/uan-config-management.git
+    images:
+      cray-application-sles15sp4.x86_64-0.5.19:
+        id: 8159f93f-7e18-4875-a8a8-b0fb83c48f07"""
+
+yaml_data_missing_main_data = """
+  component_versions:
+    docker:
+    - name: artifactory.algol60.net/uan-docker/stable/cray-uan-config
+      version: 1.11.1
+    - name: artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update
+      version: 1.3.2
+    helm:
+    - name: cray-uan-install
+      version: 1.11.1
+    repositories:
+    - members:
+      - uan-2.6.0-sle-15sp4
+      name: uan-2.6-sle-15sp4
+      type: group
+    manifests:
+    - config-data/argo/loftsman/uan/2.6.0-rc.1/manifests/uan.yaml"""
+
+
+def test_split_data_sanity():
+    """sanity check of split of yaml into main and prod specific data | +ve test case"""
+
+    # expected data
+    main_cm_data_expected = {
+        'active': False,
+        'configuration':
+            {
+                'clone_url': 'https://vcs.cmn.lemondrop.hpc.amslabs.hpecorp.net/vcs/cray/uan-config-management.git',
+                'commit': '6a5f52dfbfe7ea1a5f8ea5079c50995112c17025',
+                'import_branch': 'cray/uan/2.6.0-rc.1-3-gcc65df9',
+                'import_date': datetime.datetime(2023, 4, 12, 14, 31, 40, 364230),
+                'ssh_url': 'git@vcs.cmn.lemondrop.hpc.amslabs.hpecorp.net:cray/uan-config-management.git',
+                'images': {'cray-application-sles15sp4.x86_64-0.5.19': {'id': '8159f93f-7e18-4875-a8a8-b0fb83c48f07'}}
+            }
+    }
+    prod_cm_data_expected = {
+        'component_versions':
+            {
+                'docker': [
+                    {'name': 'artifactory.algol60.net/uan-docker/stable/cray-uan-config', 'version': '1.11.1'},
+                    {'name': 'artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update',
+                     'version': '1.3.2'}],
+                'helm': [
+                    {'name': 'cray-uan-install', 'version': '1.11.1'}],
+                'repositories': [
+                    {'members': ['uan-2.6.0-sle-15sp4'], 'name': 'uan-2.6-sle-15sp4', 'type': 'group'}],
+                'manifests': ['config-data/argo/loftsman/uan/2.6.0-rc.1/manifests/uan.yaml']
+            }
+    }
+
+    # yaml raw to py object
+    yaml_object: Dict = yaml.safe_load(yaml_data)
+
+    main_cm_data: Dict
+    prod_cm_data: Dict
+    main_cm_data, prod_cm_data = split_catalog_data(yaml_object)
+
+    assert main_cm_data == main_cm_data_expected
+    assert prod_cm_data == prod_cm_data_expected
+
+
+def test_split_missing_prod_cm_data():
+    """missing prod cm data check"""
+
+    # expected data
+    main_cm_data_expected = {
+        'active': False,
+        'configuration':
+            {
+                'clone_url': 'https://vcs.cmn.lemondrop.hpc.amslabs.hpecorp.net/vcs/cray/uan-config-management.git',
+                'commit': '6a5f52dfbfe7ea1a5f8ea5079c50995112c17025',
+                'import_branch': 'cray/uan/2.6.0-rc.1-3-gcc65df9',
+                'import_date': datetime.datetime(2023, 4, 12, 14, 31, 40, 364230),
+                'ssh_url': 'git@vcs.cmn.lemondrop.hpc.amslabs.hpecorp.net:cray/uan-config-management.git',
+                'images': {'cray-application-sles15sp4.x86_64-0.5.19': {'id': '8159f93f-7e18-4875-a8a8-b0fb83c48f07'}}
+            }
+    }
+    prod_cm_data_expected = {}
+
+    # yaml raw to py object
+    yaml_object: Dict = yaml.safe_load(yaml_data_missing_prod_cm_data)
+
+    main_cm_data: Dict
+    prod_cm_data: Dict
+    main_cm_data, prod_cm_data = split_catalog_data(yaml_object)
+
+    assert main_cm_data == main_cm_data_expected
+    assert prod_cm_data == prod_cm_data_expected
+
+
+def test_split_missing_main_cm_data():
+    """missing main cm data check"""
+
+    # expected data
+    main_cm_data_expected = {}
+    prod_cm_data_expected = {
+        'component_versions':
+            {
+                'docker': [
+                    {'name': 'artifactory.algol60.net/uan-docker/stable/cray-uan-config', 'version': '1.11.1'},
+                    {'name': 'artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update',
+                     'version': '1.3.2'}],
+                'helm': [
+                    {'name': 'cray-uan-install', 'version': '1.11.1'}],
+                'repositories': [
+                    {'members': ['uan-2.6.0-sle-15sp4'], 'name': 'uan-2.6-sle-15sp4', 'type': 'group'}],
+                'manifests': ['config-data/argo/loftsman/uan/2.6.0-rc.1/manifests/uan.yaml']
+            }
+    }
+
+    # yaml raw to py object
+    yaml_object: Dict = yaml.safe_load(yaml_data_missing_main_data)
+
+    main_cm_data: Dict
+    prod_cm_data: Dict
+    main_cm_data, prod_cm_data = split_catalog_data(yaml_object)
+
+    assert main_cm_data == main_cm_data_expected
+    assert prod_cm_data == prod_cm_data_expected
+
+
+def test_format_product_cm_name_sanity():
+    """Unit test case for product name formatting"""
+    product_name = "dummy-valid-1"
+    config_map = "cm"
+    assert format_product_cm_name(config_map, product_name) == f"{config_map}-{product_name}"
+
+
+def test_format_product_name_transform():
+    """Unit test case for valid product name transformation"""
+    product_name = "23dummy_valid-1.x86"
+    config_map = "cm"
+    assert format_product_cm_name(config_map, product_name) == f"{config_map}-23dummy-valid-1.x86"
+
+
+def test_format_product_name_invalid_cases():
+    """Unit test case for valid product name transformation"""
+
+    # case with special characters
+    product_name = "po90-$_invalid"
+    config_map = "cm"
+    assert format_product_cm_name(config_map, product_name) == ""
+
+    # large name cases
+    product_name = "ola-9" * 60
+    config_map = "cm"
+    assert format_product_cm_name(config_map, product_name) == ""
+
+    # large name cases
+    product_name = "ola-9" * 60
+    config_map = ""
+    assert format_product_cm_name(config_map, product_name) == ""


### PR DESCRIPTION
## Summary and Scope

Split config map to store component-versions field of cray-product-catalog under another config map.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
- [ ] Is a new version being released? Update https://github.com/Cray-HPE/cray-product-catalog/wiki/CSM-Compatibility-Matrix
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

