### PR TITLE
CASMCMS-8914: Use appropriate version of Python k8s client for CSM 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Dependencies
+- Regress `kubernetes` from 26.1.0 to 22.6.0 to match CSM 1.6 Kubernetes version
+
 ## [2.0.0] - 2024-02-08
 
 ### Changed

--- a/constraints.txt
+++ b/constraints.txt
@@ -5,7 +5,8 @@ charset-normalizer==3.2.0
 google-auth==2.22.0
 idna==3.4
 jsonschema==4.18.6
-kubernetes==26.1.0
+# CSM 1.6 uses Kubernetes 1.22, so use client v22.x to ensure compatability
+kubernetes==22.6.0
 oauthlib==3.2.2
 pip==23.2.1
 pyasn1==0.5.1


### PR DESCRIPTION
I noticed that some of our Python code for CSM 1.6 is pulling in non-optimal versions of the Kubernetes client library. Ideally the major version of the library should correspond to the Kubernetes version on the system, but in many cases it is not. This doesn't guarantee that there will be problems, but it's least risky to use the appropriate version.

This problem also exists in past CSM versions, but this is not the kind of thing worth backporting without additional reason, so I'll just confine my change to CSM 1.6.
