### PR TITLE
CASMTRIAGE-6794: Improve logging in catalog_update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2024-03-20
+
+### Changed
+- CASMTRIAGE-6794: Improved logging in [`catalog_update.py`](cray_product_catalog/catalog_update.py),
+  including changing logging which caused IUF to incorrectly think the catalog update failed.
+
 ### Dependencies
 - Bump `cachetools` from 5.3.2 to 5.3.3 ([#315](https://github.com/Cray-HPE/cray-product-catalog/pull/315))
 - Bump `tj-actions/changed-files` from 42 to 43 ([#316](https://github.com/Cray-HPE/cray-product-catalog/pull/316))
@@ -468,7 +474,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change default reviewers to CMS-core-product-support
 
-[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog/compare/v2.1.0...HEAD
+
+[2.1.0]: https://github.com/Cray-HPE/cray-product-catalog/compare/v2.0.1...v2.1.0
 
 [2.0.1]: https://github.com/Cray-HPE/cray-product-catalog/compare/v2.0.0...v2.0.1
 

--- a/tests/test_update_catalog.py
+++ b/tests/test_update_catalog.py
@@ -78,8 +78,8 @@ class TestCatalogUpdate(unittest.TestCase):
             except ApiException:
                 pass
             self.assertEqual(len(captured.records), 1)  # check that there is only one log message
-            self.assertEqual(captured.records[0].getMessage(),
-                             "Error calling create_namespaced_config_map")  # Verify the exact log message
+            expected_log = f"Error calling create_namespaced_config_map on ConfigMap {namespace}/{name}"
+            self.assertEqual(captured.records[0].getMessage(), expected_log)  # Verify the exact log message
 
     def test_update_config_map_max_retries(self):
         """


### PR DESCRIPTION
## Summary and Scope

One of the logging calls was tricking IUF into thinking that the update failed, when in fact it had not. I corrected that with this PR, and also added a little more information to a few other logging calls.

I also changed the `create_config_map` function in the `catalog_update` module so that it raises an exception to indicate failure, rather than returning a boolean. This allows for simpler debugging in the case that it fails. It is also the reason I chose to bump the minor number with this change. Even though that function is new in version 2.0, and thus I doubt anyone has written any Python code to use it outside of this repo, it nevertheless is a breaking change which should not be under a mere patch number bump.

## Issues and Related PRs

[CASMTRIAGE-6794](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6794)

