### PR TITLE
CASMCMS-9012: Allow Python module installs from source to work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CASMCMS-9012: Modify build process to remove dependencies on additional files from `setup.py`. This should allow installs from the
+  Python module source files to work.
+
 ### Dependencies
 - Bump `tj-actions/changed-files` from 43 to 44 ([#320](https://github.com/Cray-HPE/cray-product-catalog/pull/320))
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,12 +23,10 @@
 #
 FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.15 as base
 RUN apk add --no-cache py3-pip python3
-ARG PYMOD_VERSION=0.0.0
 
 WORKDIR /src/
 COPY cray_product_catalog/ ./cray_product_catalog
 COPY setup.py requirements.txt constraints.txt README.md ./
-RUN echo ${PYMOD_VERSION} > .version
 
 RUN apk add --upgrade --no-cache apk-tools \
     && apk update \

--- a/setup.py
+++ b/setup.py
@@ -29,24 +29,11 @@ from setuptools import setup, find_packages
 
 here = path.abspath(path.dirname(__file__))
 
-with open(path.join(here, '.version'), encoding='utf-8') as f:
-    version = f.read().strip()
-
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
-    long_description = f.read()
-
-with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
-    install_requires = []
-    for line in f.readlines():
-        if line and line[0].isalpha():
-            install_requires.append(line.strip())
-
+# The version is set at build time
 setup(
     name='cray-product-catalog',
-    version=version,
+    version= "@RPM_VERSION@",
     description='Cray Product Catalog',
-    long_description=long_description,
-    long_description_content_type='text/markdown',
     url='https://github.com/Cray-HPE/cray-product-catalog',
     author='Hewlett Packard Enterprise Development LP',
     license='MIT',
@@ -54,9 +41,7 @@ setup(
     package_data={
         'cray_product_catalog.schema': ['schema.yaml']
     },
-    python_requires='>=3, <4',
-    # Top-level dependencies are parsed from requirements.txt
-    install_requires=install_requires,
+    python_requires='>=3.9, <4',
     entry_points={
         'console_scripts': [
             'catalog_delete=cray_product_catalog.catalog_delete:main',

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -34,3 +34,7 @@ sourcefile-novalidate: .stable
 tag: S-T-A-B-L-E
 targetfile: charts/cray-product-catalog/Chart.yaml
 targetfile: charts/cray-product-catalog/values.yaml
+
+sourcefile: .version
+tag: @RPM_VERSION@
+targetfile: setup.py


### PR DESCRIPTION
This will allow the Python module to be installed from source (rather than just from the wheel).