### PR TITLE
CASM-4727: Migrate all products to latest version of cpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CASM-4731: change to adapt cray-product-catalog to include empty dictionary objects [`config_map_data_handler.py`](cray_product_catalog/migration/config_map_data_handler.py)
+- CASM-4741: give a warning instead of raising exception if product configmap is not present [`catalog_update.py`](cray_product_catalog/catalog_delete.py)
+- CASM-4743: add check if the configmap has already been migrated before attempting to migrate [`main.py`](cray_product_catalog/migration/main.py)
+
 ### Dependencies
 - Bump `urllib3` from 1.26.18 to 1.26.19 ([#324](https://github.com/Cray-HPE/cray-product-catalog/pull/324))
 

--- a/cray_product_catalog/catalog_delete.py
+++ b/cray_product_catalog/catalog_delete.py
@@ -220,11 +220,10 @@ class ModifyConfigMapUtil:
 
         self.__modify_main_cm()
 
-        """Invoke __modify_product_cm function only if the product_cm is present
+        # Invoke __modify_product_cm function only if the product_cm is present
 
-        Before attempting to delete a configmap, first verify if for the product there is a product_cm present or not.
-        If not, give a warning message and continue
-        """
+        # Before attempting to delete a ConfigMap, first verify if for the product there is a product_cm present or not.
+        # If not, give a warning message and continue
         k8sclient = ApiClient()
         name = self.__product_cm
         namespace = self.__cm_namespace

--- a/cray_product_catalog/migration/config_map_data_handler.py
+++ b/cray_product_catalog/migration/config_map_data_handler.py
@@ -118,6 +118,9 @@ class ConfigMapDataHandler:
                 # main_cm_data is not an empty dictionary
                 if main_cm_data:
                     main_versions_data[version_data] = main_cm_data
+                # create an empty dictionary entry for the version
+                else:
+                    main_versions_data[version_data] = {}
             # If `component_versions` data exists for a product, create new product ConfigMap
             if product_versions_data:
                 product_config_map_data = {
@@ -129,7 +132,7 @@ class ConfigMapDataHandler:
             if main_versions_data:
                 config_map_data[product] = yaml.safe_dump(main_versions_data, default_flow_style=False)
             else:
-                config_map_data[product] = ''
+                config_map_data[product] = yaml.safe_dump({}, default_flow_style=False)
         return config_map_data, product_config_map_data_list
 
     def rename_config_map(self, rename_from, rename_to, namespace, label):

--- a/cray_product_catalog/migration/main.py
+++ b/cray_product_catalog/migration/main.py
@@ -44,8 +44,11 @@ from cray_product_catalog.migration.exit_handler import ExitHandler
 LOGGER = logging.getLogger(__name__)
 
 
-# function to check if configmap is already migrated
 def is_migrated():
+   """
+   Check if ConfigMap is already migrated.
+   Returns True if so, False if not.
+   """
     config_map_obj = ConfigMapDataHandler()
     try:
         main_cm = config_map_obj.k8s_obj.read_config_map(
@@ -64,7 +67,7 @@ def is_migrated():
 def main():
     """Main function"""
 
-    # check if configmap has already been migrated
+    # Check if ConfigMap has already been migrated
     if is_migrated():
         LOGGER.info("Configmap %s already migrated", PRODUCT_CATALOG_CONFIG_MAP_NAME)
         return

--- a/cray_product_catalog/migration/main.py
+++ b/cray_product_catalog/migration/main.py
@@ -45,10 +45,10 @@ LOGGER = logging.getLogger(__name__)
 
 
 def is_migrated():
-   """
-   Check if ConfigMap is already migrated.
-   Returns True if so, False if not.
-   """
+    """
+    Check if ConfigMap is already migrated.
+    Returns True if so, False if not.
+    """
     config_map_obj = ConfigMapDataHandler()
     try:
         main_cm = config_map_obj.k8s_obj.read_config_map(

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'cray_product_catalog.schema': ['schema.yaml']
     },
     python_requires='>=3.9, <4',
+    include_package_data=True,
     entry_points={
         'console_scripts': [
             'catalog_delete=cray_product_catalog.catalog_delete:main',

--- a/tests/migration/migration_mock.py
+++ b/tests/migration/migration_mock.py
@@ -64,7 +64,8 @@ INITIAL_MAIN_CM_DATA = {
 }
 
 MAIN_CM_DATA_EXPECTED = {
-    'HFP-firmware': '',
+    'HFP-firmware': """22.10.2: {}
+23.01.1: {}\n""",
     'analytics': """1.4.18:
   configuration:
     clone_url: https://vcs.cmn.lemondrop.hpc.amslabs.hpecorp.net/vcs/cray/analytics-config-management.git

--- a/tests/migration/test_config_map_data_handler.py
+++ b/tests/migration/test_config_map_data_handler.py
@@ -599,6 +599,9 @@ class TestConfigMapDataHandler(unittest.TestCase):
         self.mock_rename_cm = patch(
             'cray_product_catalog.migration.config_map_data_handler.ConfigMapDataHandler.rename_config_map'
         ).start()
+        self.mock_is_migrated = patch(
+            'cray_product_catalog.migration.main.is_migrated'
+        ).start()
 
         with self.assertRaises(SystemExit) as captured:
             self.mock_k8api_read.side_effect = [MockYaml(1),
@@ -608,6 +611,7 @@ class TestConfigMapDataHandler(unittest.TestCase):
             self.mock_migrate_config_map.return_value = mock_split_catalog_data()
             self.mock_create_prod_cms.return_value = True
             self.mock_create_temp_cm.return_value = True
+            self.mock_is_migrated.return_value = False
 
             # Call method under test
             main()
@@ -641,6 +645,9 @@ class TestConfigMapDataHandler(unittest.TestCase):
         self.mock_rename_cm = patch(
             'cray_product_catalog.migration.config_map_data_handler.ConfigMapDataHandler.rename_config_map'
         ).start()
+        self.mock_is_migrated = patch(
+            'cray_product_catalog.migration.main.is_migrated'
+        ).start()
 
         with self.assertLogs(level="DEBUG") as captured:
             # with self.assertRaises(SystemExit) as captured:
@@ -652,6 +659,7 @@ class TestConfigMapDataHandler(unittest.TestCase):
             self.mock_create_prod_cms.return_value = True
             self.mock_create_temp_cm.return_value = True
             self.mock_rename_cm.return_value = True
+            self.mock_is_migrated.return_value = False
 
             # Call method under test
             main()

--- a/tests/test_catalog_delete.py
+++ b/tests/test_catalog_delete.py
@@ -24,7 +24,9 @@ File contains unit test classes for validating ConfigMap deletion logic.
 Deleting keys/product or a specific version of a product from ConfigMap
 """
 import unittest
+from unittest import mock
 from unittest.mock import patch, call
+from tests.mock_update_catalog import ApiInstance
 
 from cray_product_catalog.catalog_delete import ModifyConfigMapUtil
 
@@ -46,6 +48,15 @@ class TestModifyConfigMapUtil(unittest.TestCase):
         self.modify_config_map_util.key = "key"
         self.modify_config_map_util.main_cm_fields = ["main_a", "main_b", "main_c"]
         self.modify_config_map_util.product_cm_fields = ["prod_1", "prod_2", "prod_3"]
+        self.mock_ApiClient = mock.patch('cray_product_catalog.catalog_delete.ApiClient').start()
+        self.mock_client = mock.patch('cray_product_catalog.catalog_delete.client').start()
+        self.mock_api_instance = mock.patch(
+                'cray_product_catalog.catalog_delete.client.CoreV1Api', return_value=ApiInstance(raise_exception=False)
+        ).start()
+        self.mock_api_instance.return_value.count = 1
+        self.mock_read_config_map = mock.patch(
+            'cray_product_catalog.catalog_delete.client.CoreV1Api.read_namespaced_config_map'
+            ).start()
 
     def tearDown(self) -> None:
         patch.stopall()


### PR DESCRIPTION
## Summary and Scope

The changes are related to the new format of cray-product-catalog . The PR involves changes for three JIRAs attached below.

Two of them are bug fixes (4741 and 4743).

The third one involves design change to make the format of cray-product-catalog after migration more efficient and compatible. (4731) 
More details are present in the JIRA regarding all the code changes.

Also there is a change in setup.py to make use of the cpc module in iuf-cli code .

## Issues and Related PRs

* Resolves [CASM-4731](https://jira-pro.it.hpe.com:8443/browse/CASM-4731), [CASM-4743](https://jira-pro.it.hpe.com:8443/browse/CASM-4743), [CASM-4741](https://jira-pro.it.hpe.com:8443/browse/CASM-4741)

### Tested on:

  * starlord

## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
