### PR TITLE
CASMCMS-9098: Restore long_description and install_requires to setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- CASMCMS-9098: Restore `install_requires` and `long_description` to Python module by creating [`MANIFEST.in`](MANIFEST.in)
 - CASM-4815 : Updating the README to include information on migration of cray-product-catalog configmap.
 - List installed Python packages in Dockerfile, for build logging purposes
 - Pin major and minor versions of Python dependencies, but use latest patch version

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apk add --no-cache py3-pip python3
 
 WORKDIR /src/
 COPY cray_product_catalog/ ./cray_product_catalog
-COPY setup.py requirements.txt constraints.txt README.md ./
+COPY setup.py requirements.txt constraints.txt README.md MANIFEST.in ./
 
 RUN apk add --upgrade --no-cache apk-tools \
     && apk update \

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include README.md

--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,22 @@ from setuptools import setup, find_packages
 
 here = path.abspath(path.dirname(__file__))
 
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
+    install_requires = []
+    for line in f.readlines():
+        if line and line[0].isalpha():
+            install_requires.append(line.strip())
+
 # The version is set at build time
 setup(
     name='cray-product-catalog',
-    version= "@RPM_VERSION@",
+    version='@RPM_VERSION@',
     description='Cray Product Catalog',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     url='https://github.com/Cray-HPE/cray-product-catalog',
     author='Hewlett Packard Enterprise Development LP',
     license='MIT',
@@ -41,6 +52,7 @@ setup(
     package_data={
         'cray_product_catalog.schema': ['schema.yaml']
     },
+    install_requires=install_requires,
     python_requires='>=3.9, <4',
     include_package_data=True,
     entry_points={


### PR DESCRIPTION
This reverts most of the changes in [this commit](https://github.com/Cray-HPE/cray-product-catalog/commit/0f0eec53d5e1d53ec58b2e46e96ef16b3e99b6e5) and instead creates a `MANIFEST.in` file to include the necessary files in order for source installs of the module to work.

The one exception is that I did not revert the version change, but that is just because the version string was being dynamically set either way, and this way is simpler than the previous way.

Thanks to @haasken-hpe for the help with this,