### PR TITLE
CASMCMS-9132 - update the version of docker-kubectl for k8s 1.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Dependencies
-- CSM 1.6 moved to Kubernetes 1.24, so use client v24.x to ensure compatability
+- CSM 1.6 moved to Kubernetes 1.24, so use client v24.x to ensure compatibility
+- CASMCMS-9132 - updated to 'docker-kubectl' image version 1.24.17 for the Kubernetes 1.24 upgrade.
 
 ## [2.3.1] - 2024-08-15
 

--- a/charts/cray-product-catalog/Chart.yaml
+++ b/charts/cray-product-catalog/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/charts/cray-product-catalog/Chart.yaml
+++ b/charts/cray-product-catalog/Chart.yaml
@@ -40,5 +40,5 @@ annotations:
     - name: cray-product-catalog-update
       image: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-product-catalog-update:0.0.0-docker
     - name: docker-kubectl
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
   artifacthub.io/license: MIT

--- a/charts/cray-product-catalog/values.yaml
+++ b/charts/cray-product-catalog/values.yaml
@@ -24,7 +24,7 @@
 kubectl:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.19.15
+    tag: 1.24.17
 migration:
   image:
     repository: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-product-catalog-update


### PR DESCRIPTION
## Summary and Scope

To keep up with the k8s api, update the version of the docker-kubectl image being used to update the product catalog.

## Issues and Related PRs
* Resolves [CASMCMS-9132](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9132)

## Testing
### Tested on:
  * `Mug`

### Test description:

Created an updated manifest with the new product-catalog and image version overrides in the csm-config and barebones image impor jobs, then installed with loftsman. Verified the imports happened correctly and the product catalog was updated.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk change - just keeping up with the current k8s api.

## Pull Request Checklist
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

