### PR TITLE
CASMCMS-9142: Fix Python-related build failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CASMCMS-9142: Install Python modules using `--user` to prevent build failures, and build inside Docker container
+
 ## [2.4.0] - 2024-09-09
 
 ### Dependencies

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),
@@ -26,6 +26,8 @@
 
 @Library('cms-meta-tools') _
 @Library('csm-shared-library') __
+
+def pyImage = 'artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python'
 
 pipeline {
     agent {
@@ -104,6 +106,13 @@ pipeline {
                 }
 
                 stage('Python Package'){
+                    agent {
+                        docker {
+                            args "-v /home/jenkins/.ssh:/home/jenkins/.ssh -v /home/jenkins/.netrc:/home/jenkins/.netrc"
+                            reuseNode true
+                            image "${pyImage}:3.10"
+                        }
+                    }
                     steps {
                         sh "make pymod_prepare"
                         sh "make pymod_build"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -60,17 +60,17 @@ chart_test:
 		docker run --rm -v ${PWD}/${CHART_PATH}:/apps ${HELM_UNITTEST_IMAGE} -3 ${NAME}
 
 pymod_prepare:
-		pip3 install --upgrade pip setuptools wheel
+		pip3 install --upgrade --user pip setuptools wheel
 
 pymod_build:
 		python3 setup.py sdist bdist_wheel
 
 pymod_test:
-		pip3 install -r requirements.txt
-		pip3 install -r requirements-test.txt
+		pip3 install --user -r requirements.txt
+		pip3 install --user -r requirements-test.txt
 		mkdir -p pymod_test
 		python3 setup.py install --user
 		python3 -m unittest discover tests
-		pycodestyle --config=.pycodestyle cray_product_catalog tests
+		python3 -m pycodestyle --config=.pycodestyle cray_product_catalog tests
 		# Run pylint, but only fail the build if the code scores lower than 8.0
-		pylint --fail-under=8.0 --rcfile=.pylintrc cray_product_catalog tests
+		python3 -m pylint --fail-under=8.0 --rcfile=.pylintrc cray_product_catalog tests


### PR DESCRIPTION
A change on the Jenkins builders has broken how this repo builds its Python module. This PR fixes it by moving that build into a Docker container and installing Python modules using `--user`.