### PR TITLE
CASMCMS-9508: Use v2.8 of product catalog Python package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Dependencies
+- CASMCMS-9508: Use 2.8 version of `cray-product-catalog` Python module
+
 ## [2.7.1] - 2025-07-02
 
 ### Dependencies

--- a/constraints.txt
+++ b/constraints.txt
@@ -2,7 +2,7 @@ attrs>=23.1,<23.2
 cachetools>=5.3.3,<5.4
 certifi==2023.7.22
 charset-normalizer>=3.2.0,<3.3
-cray-product-catalog>=2.7,<2.8
+cray-product-catalog>=2.8,<2.9
 google-auth>=2.22,<2.23
 idna>=3.4,<3.5
 jsonschema>=4.18.6,<4.19


### PR DESCRIPTION
This package was updated by [CRAYSAT-1944](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1944) to improve its performance. This just picks up those changes.